### PR TITLE
feat(registry): add dsh-skin-rotator

### DIFF
--- a/registry/skins/wensincai__dsh-skin-rotator.yml
+++ b/registry/skins/wensincai__dsh-skin-rotator.yml
@@ -1,11 +1,11 @@
 id: wensincai.dsh-skin-rotator
 name:
-  zh: 动态背景轮播皮肤
+  zh: åŠ¨æ€èƒŒæ™¯è½®æ’­çš®è‚¤
   en: dsh-skin-rotator
 author: wensincai
 description: >-
-  DSH Web 动态背景皮肤：把本地图片目录的图片每 5 分钟轮播一张作为全屏背景，
-  叠加可调黑色蒙版，并自动切换暗色主题保证文字可读。
+  DSH Web åŠ¨æ€èƒŒæ™¯çš®è‚¤ï¼šæŠŠæœ¬åœ°å›¾ç‰‡ç›®å½•çš„å›¾ç‰‡æ¯ 5 åˆ†é’Ÿè½®æ’­ä¸€å¼ ä½œä¸ºå…¨å±èƒŒæ™¯ï¼Œ
+  å åŠ å¯è°ƒé»‘è‰²è’™ç‰ˆï¼Œå¹¶è‡ªåŠ¨åˆ‡æ¢æš—è‰²ä¸»é¢˜ä¿è¯æ–‡å­—å¯è¯»ã€‚
 repo: https://github.com/wensincai/dsh-skin-rotator
 package: dsh-skin-rotator
 rowId: skin-rotator
@@ -18,15 +18,15 @@ tags:
 modes:
   - dark
 install:
-  target: 'github:wensincai/dsh-skin-rotator#d902b17a6fbfaf2c4cad189c361edc80e5fd721a'
+  target: 'github:wensincai/dsh-skin-rotator#a04cdc926dec980ef946731318d74d4e44167dac'
   version: 0.1.1
-  commit: 'd902b17a6fbfaf2c4cad189c361edc80e5fd721a'
+  commit: 'a04cdc926dec980ef946731318d74d4e44167dac'
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/wensincai/dsh-skin-rotator/d902b17a6fbfaf2c4cad189c361edc80e5fd721a/docs/screenshot.png
+  - https://raw.githubusercontent.com/wensincai/dsh-skin-rotator/a04cdc926dec980ef946731318d74d4e44167dac/docs/screenshot.png
 review:
   compatibility: unverified
   preview: verified

--- a/registry/skins/wensincai__dsh-skin-rotator.yml
+++ b/registry/skins/wensincai__dsh-skin-rotator.yml
@@ -1,0 +1,42 @@
+id: wensincai.dsh-skin-rotator
+name:
+  zh: 动态背景轮播皮肤
+  en: dsh-skin-rotator
+author: wensincai
+description: >-
+  DSH Web 动态背景皮肤：把本地图片目录的图片每 5 分钟轮播一张作为全屏背景，
+  叠加可调黑色蒙版，并自动切换暗色主题保证文字可读。
+repo: https://github.com/wensincai/dsh-skin-rotator
+package: dsh-skin-rotator
+rowId: skin-rotator
+category: background
+tags:
+  - dynamic-background
+  - wallpaper-rotation
+  - local-images
+  - dark-overlay
+modes:
+  - dark
+install:
+  target: 'github:wensincai/dsh-skin-rotator#d902b17a6fbfaf2c4cad189c361edc80e5fd721a'
+  version: 0.1.1
+  commit: 'd902b17a6fbfaf2c4cad189c361edc80e5fd721a'
+compatibility:
+  dsh: 0.1.0-rc.6
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/wensincai/dsh-skin-rotator/d902b17a6fbfaf2c4cad189c361edc80e5fd721a/docs/screenshot.png
+review:
+  compatibility: unverified
+  preview: verified
+  installation: verified
+license:
+  code: MIT
+  commercialUse: true
+featuredRank: 0
+starsSnapshot: 0
+releaseUpdatedAt: '2026-08-19T04:08:02.180Z'
+metadataUpdatedAt: '2026-08-19T04:08:02.180Z'
+starsUpdatedAt: '2026-08-19T04:08:02.180Z'
+updatedAt: '2026-08-19T04:08:02.180Z'


### PR DESCRIPTION
## 皮肤
- **名称**: dsh-skin-rotator（动态背景轮播皮肤）
- **仓库**: https://github.com/wensincai/dsh-skin-rotator
- **package**: `dsh-skin-rotator`，**rowId**: `skin-rotator`
- **版本**: 0.1.1，**固定 commit**: `d902b17a6fbfaf2c4cad189c361edc80e5fd721a`
- **许可证**: MIT（commercialUse: true）
- **预览图**: 真实 DSH Web 界面截图（docs/screenshot.png，已固定 commit）

## 功能
DSH Web 动态背景皮肤：把本地 `images/` 目录的图片每 5 分钟轮播一张作为全屏背景，叠加可调黑色蒙版（默认 35%），并自动切换暗色主题保证文字可读。host 半通过 webserver 暴露图片目录路由，client 半轮播；图片不入库（BYO）。

## 自动检查
- `npm run registry:check` 通过（validated 142 skins）
- 本机已实测：`dsh plugin add` 安装成功、Web 实机挂载生效、离线可运行

## 兼容性
- 声明 dsh `0.1.0-rc.6`（`compatibility: unverified`）；作者在 **rc.7** 实测通过（所用 API：`webServer.register`、client `__ModuleLoader__` 均未变化）
- 平台 web；皮肤自带 `dsh.bundle` + `dsh.client` 双半声明

## 需人工确认
- 请复核预览截图与安装流程（`installation: verified` 为作者自测结论）
- 皮肤强制暗色主题（`body[data-ds-dark-theme]`）