### PR TITLE
chore: clean invalid screenshots from registry

### DIFF
--- a/registry/skins/1MLightyears__dsh-theme-synthwave.yml
+++ b/registry/skins/1MLightyears__dsh-theme-synthwave.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-synthwave
   en: dsh-theme-synthwave
 author: 1MLightyears
-description: 给 DSH（DeepSeek Harness）Web UI 用的合成波 / Synthwave 主题插件。
+description: A synthwave style DeepSeek Harness(dsh) theme
 repo: https://github.com/1MLightyears/dsh-theme-synthwave
 package: "@1mlightyears/dsh-theme-synthwave"
 rowId: theme-synthwave
@@ -48,6 +48,6 @@ license:
 featuredRank: 167
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:00.135Z
-metadataUpdatedAt: 2026-08-19T04:38:50.080Z
+metadataUpdatedAt: 2026-08-18T15:44:00.135Z
 starsUpdatedAt: 2026-08-18T15:44:00.135Z
-updatedAt: 2026-08-19T04:38:50.080Z
+updatedAt: 2026-08-18T15:44:00.135Z

--- a/registry/skins/54088lp__dsh-kafka-ui.yml
+++ b/registry/skins/54088lp__dsh-kafka-ui.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-kafka-ui
   en: dsh-kafka-ui
 author: 54088lp
-description: dsh-卡芙卡-ui
+description: "Kafka (Honkai: Star Rail) theme skin for DeepSeek Harness web GUI"
 repo: https://github.com/54088lp/dsh-kafka-ui
 package: "@dsh-external/dsh-client-ui-skin-kafka"
 rowId: ui-skin-kafka
@@ -43,8 +43,8 @@ license:
   code: CC-BY-NC-SA-4.0
   commercialUse: false
 featuredRank: 168
-starsSnapshot: 1
+starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:02.099Z
-metadataUpdatedAt: 2026-08-19T04:36:45.516Z
-starsUpdatedAt: 2026-08-19T04:36:45.516Z
-updatedAt: 2026-08-19T04:36:45.516Z
+metadataUpdatedAt: 2026-08-18T15:44:02.099Z
+starsUpdatedAt: 2026-08-18T15:44:02.099Z
+updatedAt: 2026-08-18T15:44:02.099Z

--- a/registry/skins/ADAning__dsh-pixel-skin.yml
+++ b/registry/skins/ADAning__dsh-pixel-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-pixel-skin
   en: dsh-pixel-skin
 author: ADAning
-description: <img src="assets/dsh-pixel-icon.svg" width="96" height="96" alt="dsh-pixel-skin 鲸鱼图标" /
+description: 8-bit / CRT skin plugin for the DeepSeek Harness web GUI
 repo: https://github.com/ADAning/dsh-pixel-skin
 package: dsh-pixel-skin
 rowId: dsh-pixel-skin
@@ -49,6 +49,6 @@ license:
 featuredRank: 98
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:03.968Z
-metadataUpdatedAt: 2026-08-19T04:38:52.270Z
+metadataUpdatedAt: 2026-08-18T15:44:03.968Z
 starsUpdatedAt: 2026-08-16T13:54:49.092Z
-updatedAt: 2026-08-19T04:38:52.270Z
+updatedAt: 2026-08-18T15:44:03.968Z

--- a/registry/skins/AKS1st__dsh-cyber-particle.yml
+++ b/registry/skins/AKS1st__dsh-cyber-particle.yml
@@ -46,8 +46,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 25
-starsSnapshot: 10
+starsSnapshot: 9
 releaseUpdatedAt: 2026-08-18T15:39:29.241Z
 metadataUpdatedAt: 2026-08-18T15:39:29.241Z
-starsUpdatedAt: 2026-08-19T04:34:03.093Z
-updatedAt: 2026-08-19T04:34:03.093Z
+starsUpdatedAt: 2026-08-18T15:39:29.241Z
+updatedAt: 2026-08-18T15:39:29.241Z

--- a/registry/skins/AKS1st__ikun-theme-skin.yml
+++ b/registry/skins/AKS1st__ikun-theme-skin.yml
@@ -9,14 +9,14 @@ package: ikun-theme-skin
 rowId: ikun-theme-skin
 category: theme
 tags:
-- wallpaper
-- glass
-- retro
-- motion
-- token-theme
+  - wallpaper
+  - glass
+  - retro
+  - motion
+  - token-theme
 modes:
-- light
-- dark
+  - light
+  - dark
 install:
   target: github:AKS1st/ikun-theme-skin#c0e59e61332a5e3317365848f73240308d9d9345
   version: 1.0.0
@@ -24,7 +24,7 @@ install:
 compatibility:
   dsh: unverified
   platform:
-  - web
+    - web
 screenshots: []
 review:
   compatibility: unverified
@@ -39,18 +39,18 @@ health:
     installCommand: pass
     topic: pass
   suggestions:
-  - 建议在 README 中加入至少一张仓库内的真实界面截图，并让图片路径随仓库一起版本化，方便用户预览和市场稳定展示。
-  - 建议在 README 或 package.json 中明确声明支持的 DSH Web 版本范围（例如 0.1.0-rc.6 或兼容区间），方便用户在安装前确认环境。
+    - 建议在 README 中加入至少一张仓库内的真实界面截图，并让图片路径随仓库一起版本化，方便用户预览和市场稳定展示。
+    - 建议在 README 或 package.json 中明确声明支持的 DSH Web 版本范围（例如 0.1.0-rc.6 或兼容区间），方便用户在安装前确认环境。
 license:
   code: MIT
   commercialUse: true
 featuredRank: 33
-starsSnapshot: 5
-releaseUpdatedAt: 2026-08-16 12:50:27.463000+00:00
-metadataUpdatedAt: 2026-08-18 15:40:30.181000+00:00
-starsUpdatedAt: 2026-08-19 04:34:37.077000+00:00
-updatedAt: 2026-08-19 04:34:37.077000+00:00
+starsSnapshot: 3
+releaseUpdatedAt: 2026-08-16T12:50:27.463Z
+metadataUpdatedAt: 2026-08-19T08:56:52.443Z
+starsUpdatedAt: 2026-08-18T15:40:30.181Z
+updatedAt: 2026-08-19T08:56:52.443Z
 marketScreenshots:
-- https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__ikun-theme-skin/c0e59e61332a5e3317365848f73240308d9d9345/home.png
-- https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__ikun-theme-skin/c0e59e61332a5e3317365848f73240308d9d9345/conversation.png
-- https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__ikun-theme-skin/c0e59e61332a5e3317365848f73240308d9d9345/settings.png
+  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__ikun-theme-skin/c0e59e61332a5e3317365848f73240308d9d9345/home.png
+  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__ikun-theme-skin/c0e59e61332a5e3317365848f73240308d9d9345/conversation.png
+  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__ikun-theme-skin/c0e59e61332a5e3317365848f73240308d9d9345/settings.png

--- a/registry/skins/Aik358__dsh-anchored-monitor.yml
+++ b/registry/skins/Aik358__dsh-anchored-monitor.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-anchored-monitor
   en: dsh-anchored-monitor
 author: Aik358
-description: English | 简体中文
+description: "Real-time chain-of-thought anchoring monitor & intervention plugin for DeepSeek Harness: three-band (spec/mixed/react) fingerprint detection, L1 hint / L2 reset / L3 restart interventions, liquid-glass web overlay + rheostat bar, standalone monitor process with JSONL experiment logs."
 repo: https://github.com/Aik358/dsh-anchored-monitor
 package: "@a9i5k4/dsh-anchored-monitor"
 rowId: anchored-monitor
@@ -41,8 +41,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 155
-starsSnapshot: 3
+starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:11.099Z
-metadataUpdatedAt: 2026-08-19T04:35:08.971Z
-starsUpdatedAt: 2026-08-19T04:35:08.971Z
-updatedAt: 2026-08-19T04:35:08.971Z
+metadataUpdatedAt: 2026-08-18T15:42:11.099Z
+starsUpdatedAt: 2026-08-18T15:42:11.099Z
+updatedAt: 2026-08-18T15:42:11.099Z

--- a/registry/skins/Andy294753951__dsh-plugin-gouden-leeuw-theme.yml
+++ b/registry/skins/Andy294753951__dsh-plugin-gouden-leeuw-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-plugin-gouden-leeuw-theme
   en: dsh-plugin-gouden-leeuw-theme
 author: Andy294753951
-description: DeepSeek Harness 金狮月泉主题
+description: Unofficial Gouden Leeuw moonlit sanctuary theme for the DeepSeek Harness web UI
 repo: https://github.com/Andy294753951/dsh-plugin-gouden-leeuw-theme
 package: dsh-plugin-gouden-leeuw-theme
 rowId: gouden-leeuw-theme
@@ -25,8 +25,7 @@ compatibility:
   dsh: 0.1.0-rc.5
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/3990dd397aec128553c7391b6d083c556483bc12/Andy294753951/dsh-plugin-gouden-leeuw-theme
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -47,6 +46,7 @@ license:
 featuredRank: 77
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:52:07.647Z
-metadataUpdatedAt: 2026-08-19T04:36:53.431Z
+metadataUpdatedAt: 2026-08-18T15:42:14.866Z
 starsUpdatedAt: 2026-08-16T13:52:07.647Z
-updatedAt: 2026-08-19T04:36:53.431Z
+updatedAt: 2026-08-18T15:42:14.866Z
+marketScreenshots: []

--- a/registry/skins/Anionex__dsh-eye-care.yml
+++ b/registry/skins/Anionex__dsh-eye-care.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-eye-care
   en: dsh-eye-care
 author: Anionex
-description: English | 中文
+description: Warm light, warm dark, and system-aware eye-care themes for DSH Web
 repo: https://github.com/Anionex/dsh-eye-care
 package: "@anionex/dsh-eye-care"
 rowId: dsh-eye-care
@@ -47,6 +47,6 @@ license:
 featuredRank: 57
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:49:43.768Z
-metadataUpdatedAt: 2026-08-19T04:35:56.273Z
+metadataUpdatedAt: 2026-08-18T15:41:15.037Z
 starsUpdatedAt: 2026-08-16T13:49:43.768Z
-updatedAt: 2026-08-19T04:35:56.273Z
+updatedAt: 2026-08-18T15:41:15.037Z

--- a/registry/skins/Ayase34__gal-view.yml
+++ b/registry/skins/Ayase34__gal-view.yml
@@ -43,8 +43,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 135
-starsSnapshot: 101
+starsSnapshot: 95
 releaseUpdatedAt: 2026-08-16T09:00:49+09:00
 metadataUpdatedAt: 2026-08-18T15:38:32.160Z
-starsUpdatedAt: 2026-08-19T04:33:11.214Z
-updatedAt: 2026-08-19T04:33:11.214Z
+starsUpdatedAt: 2026-08-18T15:38:32.160Z
+updatedAt: 2026-08-18T15:38:32.160Z

--- a/registry/skins/BPZ0726__dsh-bestui.yml
+++ b/registry/skins/BPZ0726__dsh-bestui.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-bestui
   en: dsh-bestui
 author: BPZ0726
-description: BestUI · 壁纸主题插件
+description: Adaptive wallpaper and appearance studio for the DeepSeek Harness Web UI.
 repo: https://github.com/BPZ0726/dsh-bestui
 package: dsh-bestui
 rowId: dsh-bestui
@@ -26,8 +26,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/89902526c31a4e5690df97bcb5da8ffa6a4cac3f/BPZ0726/dsh-bestui
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -48,6 +47,7 @@ license:
 featuredRank: 170
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:11.605Z
-metadataUpdatedAt: 2026-08-19T04:38:58.712Z
+metadataUpdatedAt: 2026-08-18T15:44:11.605Z
 starsUpdatedAt: 2026-08-18T15:44:11.605Z
-updatedAt: 2026-08-19T04:38:58.712Z
+updatedAt: 2026-08-18T15:44:11.605Z
+marketScreenshots: []

--- a/registry/skins/BeiZi6__dsh-theme-plugin.yml
+++ b/registry/skins/BeiZi6__dsh-theme-plugin.yml
@@ -25,8 +25,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/b3e7e143532c4b6df71da753d2336bb018949d2a/BeiZi6/dsh-theme-plugin
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -45,8 +44,9 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 26
-starsSnapshot: 3
+starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T12:16:08.600Z
 metadataUpdatedAt: 2026-08-18T15:41:16.860Z
-starsUpdatedAt: 2026-08-19T04:35:13.257Z
-updatedAt: 2026-08-19T04:35:13.257Z
+starsUpdatedAt: 2026-08-16T12:16:08.600Z
+updatedAt: 2026-08-18T15:41:16.860Z
+marketScreenshots: []

--- a/registry/skins/Carpon39038__dsh-image-theme.yml
+++ b/registry/skins/Carpon39038__dsh-image-theme.yml
@@ -24,8 +24,7 @@ compatibility:
   dsh: 0.1.0-rc.5
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/Carpon39038/dsh-image-theme/d522281fcdf81fb08984650800294b0058b89301/docs/preview.png
+screenshots: []
 review:
   compatibility: verified
   preview: verified
@@ -48,3 +47,4 @@ releaseUpdatedAt: 2026-08-16T13:50:02.941Z
 metadataUpdatedAt: 2026-08-18T15:41:22.686Z
 starsUpdatedAt: 2026-08-16T13:50:02.941Z
 updatedAt: 2026-08-18T15:41:22.686Z
+marketScreenshots: []

--- a/registry/skins/Cerrda__dsh-cerrda-theme.yml
+++ b/registry/skins/Cerrda__dsh-cerrda-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-cerrda-theme
   en: dsh-cerrda-theme
 author: Cerrda
-description: DSH（DeepSeek Harness）Web GUI 的 cerrda 暗色主题——以部署级静态 web 插件发布， 免审批、进程重启后自动加载。
+description: dsh-cerrda-theme
 repo: https://github.com/Cerrda/dsh-cerrda-theme
 package: dsh-cerrda-theme
 rowId: dsh-cerrda-theme
@@ -26,8 +26,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/4bdf404f7edac640ac32f4ae470c57ab53327634/Cerrda/dsh-cerrda-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -49,6 +48,7 @@ license:
 featuredRank: 173
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:18.391Z
-metadataUpdatedAt: 2026-08-19T04:39:05.695Z
+metadataUpdatedAt: 2026-08-18T15:44:18.391Z
 starsUpdatedAt: 2026-08-18T15:44:18.391Z
-updatedAt: 2026-08-19T04:39:05.695Z
+updatedAt: 2026-08-18T15:44:18.391Z
+marketScreenshots: []

--- a/registry/skins/CharlesAQ__dsh-fgo-chaldea.yml
+++ b/registry/skins/CharlesAQ__dsh-fgo-chaldea.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-fgo-chaldea
   en: dsh-fgo-chaldea
 author: CharlesAQ
-description: FGO 迦勒底风格的 DeepSeek Harness Web UI 皮肤插件。配色层走官方 ctx.theme token API，背景是程序生成的原创星图 / 魔术回路 SVG，外加金色刻线边框，不包含任何 FGO 官方美术素材。
+description: "FGO Chaldea-inspired skin pack for DeepSeek Harness Web UI: 5 themes, original generated backdrops, gold trim."
 repo: https://github.com/CharlesAQ/dsh-fgo-chaldea
 package: dsh-fgo-chaldea
 rowId: fgo-chaldea
@@ -25,8 +25,7 @@ compatibility:
   dsh: 0.1.0-rc.5
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/e769eb31089880d156dc0cf9e98f1fa14bb7c5b9/CharlesAQ/dsh-fgo-chaldea
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -47,6 +46,7 @@ license:
 featuredRank: 100
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:54:57.394Z
-metadataUpdatedAt: 2026-08-19T04:39:07.179Z
+metadataUpdatedAt: 2026-08-18T15:44:20.925Z
 starsUpdatedAt: 2026-08-16T13:54:57.394Z
-updatedAt: 2026-08-19T04:39:07.179Z
+updatedAt: 2026-08-18T15:44:20.925Z
+marketScreenshots: []

--- a/registry/skins/DViridescent__dafy-whale-theme.yml
+++ b/registry/skins/DViridescent__dafy-whale-theme.yml
@@ -43,6 +43,7 @@ license:
 featuredRank: 43
 starsSnapshot: 7
 releaseUpdatedAt: 2026-08-16T13:47:59.806Z
-metadataUpdatedAt: 2026-08-18T15:39:32.420Z
+metadataUpdatedAt: 2026-08-19T10:18:12.746Z
 starsUpdatedAt: 2026-08-18T15:39:32.420Z
-updatedAt: 2026-08-18T15:39:32.420Z
+updatedAt: 2026-08-19T10:18:12.746Z
+marketScreenshots: []

--- a/registry/skins/Danieltoraji__dsh-skin-kamisato.yml
+++ b/registry/skins/Danieltoraji__dsh-skin-kamisato.yml
@@ -21,8 +21,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/bf9902e49b42d213180de1a4b8b0dd4574a5ca66/Danieltoraji/dsh-skin-kamisato
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -47,3 +46,4 @@ releaseUpdatedAt: 2026-08-16T13:55:09.178Z
 metadataUpdatedAt: 2026-08-18T15:44:30.878Z
 starsUpdatedAt: 2026-08-16T13:55:09.178Z
 updatedAt: 2026-08-18T15:44:30.878Z
+marketScreenshots: []

--- a/registry/skins/DarkskyX15__dsh-client-ui-m3-theme.yml
+++ b/registry/skins/DarkskyX15__dsh-client-ui-m3-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-client-ui-m3-theme
   en: dsh-client-ui-m3-theme
 author: DarkskyX15
-description: DeepSeek Harness 的 Material 3 主题插件（双面包）：由单一主色推导整套 --dsw- color token，亮/暗模式各自成板，附带设置面板用于启用主题与选色。
+description: "Material 3 theme plugin for DeepSeek Harness: derives the full --dsw-* color token set from one primary color, with separate light/dark palettes (per-mode chroma, fixed contrast surfaces), plus a settings panel with color picker, presets and live preview."
 repo: https://github.com/DarkskyX15/dsh-client-ui-m3-theme
 package: dsh-client-ui-m3-theme
 rowId: ui-m3-theme
@@ -23,8 +23,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/5b167b8e1b544aa6224c1bb32bbb4d9a149e5f34/DarkskyX15/dsh-client-ui-m3-theme
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -46,6 +45,7 @@ license:
 featuredRank: 78
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:52:11.206Z
-metadataUpdatedAt: 2026-08-19T04:37:09.201Z
+metadataUpdatedAt: 2026-08-18T15:42:30.203Z
 starsUpdatedAt: 2026-08-16T13:52:11.206Z
-updatedAt: 2026-08-19T04:37:09.201Z
+updatedAt: 2026-08-18T15:42:30.203Z
+marketScreenshots: []

--- a/registry/skins/DevourerM__dsh-naiwa-theme.yml
+++ b/registry/skins/DevourerM__dsh-naiwa-theme.yml
@@ -45,9 +45,9 @@ license:
 featuredRank: 62
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-18 15:40:37.435000+00:00
-metadataUpdatedAt: 2026-08-18 15:40:37.435000+00:00
+metadataUpdatedAt: '2026-08-19T08:57:47.162687Z'
 starsUpdatedAt: 2026-08-18 15:40:37.435000+00:00
-updatedAt: 2026-08-18 15:40:37.435000+00:00
+updatedAt: '2026-08-19T08:57:47.162687Z'
 marketScreenshots:
 - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/DevourerM__dsh-naiwa-theme/e25421d9247aceecdc97852091991708a5897df0/home.png
 - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/DevourerM__dsh-naiwa-theme/e25421d9247aceecdc97852091991708a5897df0/conversation.png

--- a/registry/skins/EachSheep__dsh-valley-pixel-skin.yml
+++ b/registry/skins/EachSheep__dsh-valley-pixel-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-valley-pixel-skin
   en: dsh-valley-pixel-skin
 author: EachSheep
-description: 给 DSH Desktop 和 Web UI 用的田园像素皮肤。春日农场铺在背景里，侧栏改成木质面板，主要工作区使用羊皮纸色半透明表面；默认增加 7px 背景模糊，让景色能看见，正文仍然清楚。
+description: A cozy farm pixel skin for DeepSeek Harness Desktop and Web UI.
 repo: https://github.com/EachSheep/dsh-valley-pixel-skin
 package: dsh-client-ui-skin-valley-spring
 rowId: ui-skin-valley-spring
@@ -45,6 +45,6 @@ license:
 featuredRank: 175
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:34.423Z
-metadataUpdatedAt: 2026-08-19T04:39:21.037Z
+metadataUpdatedAt: 2026-08-18T15:44:34.423Z
 starsUpdatedAt: 2026-08-18T15:44:34.423Z
-updatedAt: 2026-08-19T04:39:21.037Z
+updatedAt: 2026-08-18T15:44:34.423Z

--- a/registry/skins/Ewnscat-ya__dsh-client-ui-skin-denia.yml
+++ b/registry/skins/Ewnscat-ya__dsh-client-ui-skin-denia.yml
@@ -46,8 +46,8 @@ license:
   commercialUse: false
   notice: 角色、美术和商标权利归原权利人所有；仓库声明为非官方同人作品并禁止商业使用。
 featuredRank: 133
-starsSnapshot: 20
+starsSnapshot: 18
 releaseUpdatedAt: 2026-08-18T15:39:04.526Z
 metadataUpdatedAt: 2026-08-18T15:39:04.526Z
-starsUpdatedAt: 2026-08-19T04:33:25.644Z
-updatedAt: 2026-08-19T04:33:25.644Z
+starsUpdatedAt: 2026-08-18T15:39:04.526Z
+updatedAt: 2026-08-18T15:39:04.526Z

--- a/registry/skins/FeatherHunter__dsh-opencode-palette.yml
+++ b/registry/skins/FeatherHunter__dsh-opencode-palette.yml
@@ -28,8 +28,7 @@ marketScreenshots:
   - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/FeatherHunter__dsh-opencode-palette/5aeadca70606ceb38f94080694e0c9fe47d4b10f/home.png
   - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/FeatherHunter__dsh-opencode-palette/5aeadca70606ceb38f94080694e0c9fe47d4b10f/conversation.png
   - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/FeatherHunter__dsh-opencode-palette/5aeadca70606ceb38f94080694e0c9fe47d4b10f/settings.png
-screenshots:
-  - https://raw.githubusercontent.com/FeatherHunter/dsh-opencode-palette/5aeadca70606ceb38f94080694e0c9fe47d4b10f/assets/setup-panel-zh.svg
+screenshots: []
 review:
   compatibility: unverified
   preview: verified

--- a/registry/skins/GptsApp__dsh-stylevault.yml
+++ b/registry/skins/GptsApp__dsh-stylevault.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-stylevault
   en: dsh-stylevault
 author: GptsApp
-description: English | 中文
+description: StyleVault — classic themes + Style Settings for DeepSeek Harness (30 palettes, shareable configs)
 repo: https://github.com/GptsApp/dsh-stylevault
 package: dsh-stylevault
 rowId: stylevault
@@ -51,6 +51,6 @@ license:
 featuredRank: 105
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:47.231Z
-metadataUpdatedAt: 2026-08-19T04:39:36.001Z
+metadataUpdatedAt: 2026-08-18T15:44:47.231Z
 starsUpdatedAt: 2026-08-16T13:55:39.547Z
-updatedAt: 2026-08-19T04:39:36.001Z
+updatedAt: 2026-08-18T15:44:47.231Z

--- a/registry/skins/He2way__dsh-task-console.yml
+++ b/registry/skins/He2way__dsh-task-console.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-task-console
   en: dsh-task-console
 author: He2way
-description: 一个 DeepSeek Harness (DSH) 客户端插件：为当前会话提供悬浮毛玻璃「任务控制台」。点击右下角的玻璃按钮，页面翻到背面 —— 一块毛玻璃面板上悬浮着可鼠标拖拽的卡片，实时展示后台任务、子代理、会话概览与工作区。
+description: "DSH client plugin: a floating glass task console on the back of the page — live background jobs, subagents, session overview and workspace for the current session, with mouse-draggable cards."
 repo: https://github.com/He2way/dsh-task-console
 package: dsh-task-console
 rowId: task-console
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/a3f130852db0b7d86a819a22586b3f37029ae360/He2way/dsh-task-console
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -46,6 +45,7 @@ license:
 featuredRank: 107
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:55:53.334Z
-metadataUpdatedAt: 2026-08-19T04:39:42.687Z
+metadataUpdatedAt: 2026-08-18T15:44:54.477Z
 starsUpdatedAt: 2026-08-16T13:55:53.334Z
-updatedAt: 2026-08-19T04:39:42.687Z
+updatedAt: 2026-08-18T15:44:54.477Z
+marketScreenshots: []

--- a/registry/skins/Jayliu2025-vip__dsh-fate-twin-contract.yml
+++ b/registry/skins/Jayliu2025-vip__dsh-fate-twin-contract.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-fate-twin-contract
   en: dsh-fate-twin-contract
 author: Jayliu2025-vip
-description: Fate / Twin Contract · 赤钢契约
+description: Unofficial Fate-inspired Archer × Rin skin for the DeepSeek Harness Web GUI — original fan art, light/dark modes, offline and reversible.
 repo: https://github.com/Jayliu2025-vip/dsh-fate-twin-contract
 package: dsh-fate-twin-contract
 rowId: ui-skin-fate-twin-contract
@@ -47,6 +47,6 @@ license:
 featuredRank: 108
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:55:59.921Z
-metadataUpdatedAt: 2026-08-19T04:39:48.805Z
+metadataUpdatedAt: 2026-08-18T15:45:01.008Z
 starsUpdatedAt: 2026-08-16T13:55:59.921Z
-updatedAt: 2026-08-19T04:39:48.805Z
+updatedAt: 2026-08-18T15:45:01.008Z

--- a/registry/skins/Jayliu2025-vip__dsh-theme-huluwa.yml
+++ b/registry/skins/Jayliu2025-vip__dsh-theme-huluwa.yml
@@ -22,8 +22,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/0ab3d4227105ebb20f9e8a5ffd951c38969089df/Jayliu2025-vip/dsh-theme-huluwa
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -48,3 +47,4 @@ releaseUpdatedAt: 2026-08-16T13:56:03.838Z
 metadataUpdatedAt: 2026-08-18T15:45:02.625Z
 starsUpdatedAt: 2026-08-16T13:56:03.838Z
 updatedAt: 2026-08-18T15:45:02.625Z
+marketScreenshots: []

--- a/registry/skins/Juryorca__dsh-custom-theme-import.yml
+++ b/registry/skins/Juryorca__dsh-custom-theme-import.yml
@@ -22,8 +22,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/3a501cf063b288009cf62d2f9c04c3dd59a2e74f/Juryorca/dsh-custom-theme-import
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -48,3 +47,4 @@ releaseUpdatedAt: 2026-08-18T15:42:51.227Z
 metadataUpdatedAt: 2026-08-18T15:42:51.227Z
 starsUpdatedAt: 2026-08-18T15:42:51.227Z
 updatedAt: 2026-08-18T15:42:51.227Z
+marketScreenshots: []

--- a/registry/skins/LaplaceYoung__dsh-qq2006.yml
+++ b/registry/skins/LaplaceYoung__dsh-qq2006.yml
@@ -26,7 +26,6 @@ compatibility:
 screenshots:
   - https://raw.githubusercontent.com/LaplaceYoung/dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/assets/screenshots/qq2006-window-view.webp
   - https://raw.githubusercontent.com/LaplaceYoung/dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/assets/screenshots/qq2006-window-chrome.webp
-  - https://raw.githubusercontent.com/LaplaceYoung/dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/assets/screenshots/qq2006-message-flow.webp
 review:
   compatibility: verified
   preview: verified
@@ -49,3 +48,4 @@ releaseUpdatedAt: 2026-08-16T13:47:05.463Z
 metadataUpdatedAt: 2026-08-18T15:39:06.078Z
 starsUpdatedAt: 2026-08-18T15:39:06.078Z
 updatedAt: 2026-08-18T15:39:06.078Z
+marketScreenshots: []

--- a/registry/skins/LeemanCheung__dsh-qq2007-skin.yml
+++ b/registry/skins/LeemanCheung__dsh-qq2007-skin.yml
@@ -31,7 +31,6 @@ screenshots:
   - https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/assets/runtime/retro-buddy-stage.webp
   - https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/assets/runtime/blue-glass-chrome.webp
   - https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/assets/runtime/retro-toolbar-icons.webp
-  - https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/assets/runtime/buddy-room-wallpaper.webp
 review:
   compatibility: verified
   preview: verified
@@ -54,3 +53,4 @@ releaseUpdatedAt: 2026-08-16T12:33:52.774Z
 metadataUpdatedAt: 2026-08-18T15:40:44.117Z
 starsUpdatedAt: 2026-08-18T15:40:44.117Z
 updatedAt: 2026-08-18T15:40:44.117Z
+marketScreenshots: []

--- a/registry/skins/LeemanCheung__dsh-whale-companion.yml
+++ b/registry/skins/LeemanCheung__dsh-whale-companion.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-whale-companion
   en: dsh-whale-companion
 author: LeemanCheung
-description: English | 中文
+description: A native DSH desktop whale with growth, achievements, skins, and privacy-safe progress tracking
 repo: https://github.com/LeemanCheung/dsh-whale-companion
 package: dsh-whale-companion
 rowId: whale-companion
@@ -44,6 +44,6 @@ license:
 featuredRank: 110
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:59.892Z
-metadataUpdatedAt: 2026-08-19T04:37:37.063Z
+metadataUpdatedAt: 2026-08-18T15:42:59.892Z
 starsUpdatedAt: 2026-08-18T15:42:59.892Z
-updatedAt: 2026-08-19T04:37:37.063Z
+updatedAt: 2026-08-18T15:42:59.892Z

--- a/registry/skins/Liu-ZA-81__dsh-theme-firefly.yml
+++ b/registry/skins/Liu-ZA-81__dsh-theme-firefly.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-firefly
   en: dsh-theme-firefly
 author: Liu-ZA-81
-description: dsh-theme-firefly · 流萤主题
+description: dsh-theme-firefly
 repo: https://github.com/Liu-ZA-81/dsh-theme-firefly
 package: dsh-theme-firefly
 rowId: ui-theme-firefly
@@ -17,40 +17,37 @@ modes:
   - light
   - dark
 install:
-  target: github:Liu-ZA-81/dsh-theme-firefly#43d63f24511bb1d931ea6413950350baf8c741eb
+  target: github:Liu-ZA-81/dsh-theme-firefly#edbee7165956153e48162d095ea539627e5cb416
   version: 0.1.0
-  commit: 43d63f24511bb1d931ea6413950350baf8c741eb
+  commit: edbee7165956153e48162d095ea539627e5cb416
 compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/43d63f24511bb1d931ea6413950350baf8c741eb/docs/screenshots/01-wallpaper.jpg
-  - https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/43d63f24511bb1d931ea6413950350baf8c741eb/docs/screenshots/02-boot.jpg
-  - https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/43d63f24511bb1d931ea6413950350baf8c741eb/docs/screenshots/03-firefly.jpg
-  - https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/43d63f24511bb1d931ea6413950350baf8c741eb/docs/screenshots/04-music.jpg
-  - https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/43d63f24511bb1d931ea6413950350baf8c741eb/docs/screenshots/05-emote.jpg
+screenshots: []
 review:
   compatibility: unverified
-  preview: verified
+  preview: repository-card
   installation: manual-only
 health:
   status: improvements
   checks:
-    readmeScreenshots: pass
+    readmeScreenshots: improve
     compatibility: improve
     installation: improve
     installCommand: pass
     topic: pass
   suggestions:
+    - 建议在 README 中加入至少一张仓库内的真实界面截图，并让图片路径随仓库一起版本化，方便用户预览和市场稳定展示。
     - 建议在 README 或 package.json 中明确声明支持的 DSH Web 版本范围（例如 0.1.0-rc.6 或兼容区间），方便用户在安装前确认环境。
     - 建议补全稳定的 package 名称、dsh.client Web 声明、row ID 和已构建客户端入口，以符合 dsh 插件要求并获得更顺畅的一键安装体验。
 license:
   code: MIT
   commercialUse: true
 featuredRank: 153
-starsSnapshot: 5
-releaseUpdatedAt: 2026-08-19T04:34:43.147Z
-metadataUpdatedAt: 2026-08-19T04:34:43.147Z
-starsUpdatedAt: 2026-08-19T04:34:43.147Z
-updatedAt: 2026-08-19T04:34:43.147Z
+starsSnapshot: 2
+releaseUpdatedAt: 2026-08-18T15:41:41.011Z
+metadataUpdatedAt: 2026-08-18T15:41:41.011Z
+starsUpdatedAt: 2026-08-18T15:41:41.011Z
+updatedAt: 2026-08-18T15:41:41.011Z
+marketScreenshots: []

--- a/registry/skins/MoonShadow1976__chiral-pulse.yml
+++ b/registry/skins/MoonShadow1976__chiral-pulse.yml
@@ -3,7 +3,7 @@ name:
   zh: chiral-pulse
   en: chiral-pulse
 author: MoonShadow1976
-description: CHIRAL PULSE · 手性脉冲
+description: Death Stranding skin for DeepSeek Harness UI + live heartbeat feed that pulses on agent thinking/tool execution. Whale keeps brand blue.
 repo: https://github.com/MoonShadow1976/chiral-pulse
 package: chiral-pulse
 rowId: ui-chiral-pulse
@@ -45,6 +45,6 @@ license:
 featuredRank: 65
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:50:42.859Z
-metadataUpdatedAt: 2026-08-19T04:36:21.959Z
+metadataUpdatedAt: 2026-08-18T15:41:42.500Z
 starsUpdatedAt: 2026-08-16T13:50:42.859Z
-updatedAt: 2026-08-19T04:36:21.959Z
+updatedAt: 2026-08-18T15:41:42.500Z

--- a/registry/skins/Morinissleeping__dsh-pnc-theme.yml
+++ b/registry/skins/Morinissleeping__dsh-pnc-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-pnc-theme
   en: dsh-pnc-theme
 author: Morinissleeping
-description: "受《少女前线：云图计划》(Girls' Frontline: Neural Cloud, PNC) 风格启发的 DSH Web GUI 主题插件。 <img width=\"1904\" height=\"911\" alt=\"屏幕截图 2026-08-16 111532\" src=\"https://github.com/user-attachments/assets/0d5ca23b-e24e-4ee9-9265-95aedb4b1272\" / 附上Opencode Go用量指示条。"
+description: dsh-pnc-theme
 repo: https://github.com/Morinissleeping/dsh-pnc-theme
 package: "@dsh-external/dsh-pnc-theme"
 rowId: dsh-pnc-theme
@@ -46,6 +46,6 @@ license:
 featuredRank: 115
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:56:51.169Z
-metadataUpdatedAt: 2026-08-19T04:40:26.286Z
+metadataUpdatedAt: 2026-08-18T15:45:30.801Z
 starsUpdatedAt: 2026-08-16T13:56:51.169Z
-updatedAt: 2026-08-19T04:40:26.286Z
+updatedAt: 2026-08-18T15:45:30.801Z

--- a/registry/skins/Nagi-ovo__dsh-ads.yml
+++ b/registry/skins/Nagi-ovo__dsh-ads.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-ads
   en: dsh-ads
 author: Nagi-ovo
-description: 把 DeepSeek Harness 变成 2005 年门户网站：在侧栏、对话和推理过程中加入虚构广告、假游戏与弹窗，支持中英文切换。
+description: "把 DeepSeek Harness 变成 2005 年门户网站：在侧栏、对话和推理过程中加入虚构广告、假游戏与弹窗，支持中英文切换。"
 repo: https://github.com/Nagi-ovo/dsh-ads
 package: "@dsh-external/dsh-ads"
 rowId: dsh-ads
@@ -47,8 +47,8 @@ license:
   code: BSD-3-Clause
   commercialUse: true
 featuredRank: 142
-starsSnapshot: 501
+starsSnapshot: 497
 releaseUpdatedAt: 2026-08-18T02:28:44+01:00
 metadataUpdatedAt: 2026-08-18T15:38:16.118Z
-starsUpdatedAt: 2026-08-19T04:33:01.039Z
-updatedAt: 2026-08-19T04:33:01.039Z
+starsUpdatedAt: 2026-08-18T15:38:16.118Z
+updatedAt: 2026-08-18T15:38:16.118Z

--- a/registry/skins/NoNameLeGo__dsh-catppuccin.yml
+++ b/registry/skins/NoNameLeGo__dsh-catppuccin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-catppuccin
   en: dsh-catppuccin
 author: NoNameLeGo
-description: <p align="center" <img src="assets/previews/combined.png" width="100%" alt="Catppuccin 四主题下的 DeepSeek Harness"/ </p
+description: Catppuccin themes + a toggleable glassmorphism skin for the DeepSeek Harness web GUI — Latte, Frappé, Macchiato and Mocha registered into the official theme system (Appearance settings), fully remapping the --dsw-* token ladder, with adjustable frosted glass for the top bar, sidebar, composer, stats line and trajectory view.
 repo: https://github.com/NoNameLeGo/dsh-catppuccin
 package: "@nonamelego/dsh-catppuccin"
 rowId: dsh-catppuccin
@@ -31,8 +31,6 @@ screenshots:
   - https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/frappe.png
   - https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/macchiato.png
   - https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/mocha.png
-  - https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png
-  - https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png
 review:
   compatibility: verified
   preview: verified
@@ -53,6 +51,7 @@ license:
 featuredRank: 5
 starsSnapshot: 13
 releaseUpdatedAt: 2026-08-18T15:39:36.526Z
-metadataUpdatedAt: 2026-08-19T04:33:54.505Z
+metadataUpdatedAt: 2026-08-18T15:39:36.526Z
 starsUpdatedAt: 2026-08-18T15:39:36.526Z
-updatedAt: 2026-08-19T04:33:54.505Z
+updatedAt: 2026-08-18T15:39:36.526Z
+marketScreenshots: []

--- a/registry/skins/RainbowDashy__dsh-theme-palettes.yml
+++ b/registry/skins/RainbowDashy__dsh-theme-palettes.yml
@@ -16,15 +16,14 @@ modes:
   - light
   - dark
 install:
-  target: github:RainbowDashy/dsh-theme-palettes#887d5a4ee5c037b5e69a6e867984dfb300c2dda4
+  target: github:RainbowDashy/dsh-theme-palettes#f295de20d97c1d9296ea3f45f64ab4d042b4cb1d
   version: 0.1.0
-  commit: 887d5a4ee5c037b5e69a6e867984dfb300c2dda4
+  commit: f295de20d97c1d9296ea3f45f64ab4d042b4cb1d
 compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/887d5a4ee5c037b5e69a6e867984dfb300c2dda4/RainbowDashy/dsh-theme-palettes
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -45,7 +44,8 @@ license:
   commercialUse: true
 featuredRank: 90
 starsSnapshot: 1
-releaseUpdatedAt: 2026-08-19T04:38:08.238Z
-metadataUpdatedAt: 2026-08-19T04:38:08.238Z
+releaseUpdatedAt: 2026-08-16T13:53:39.460Z
+metadataUpdatedAt: 2026-08-18T15:43:26.156Z
 starsUpdatedAt: 2026-08-16T13:53:39.460Z
-updatedAt: 2026-08-19T04:38:08.238Z
+updatedAt: 2026-08-18T15:43:26.156Z
+marketScreenshots: []

--- a/registry/skins/RayYeung1989__claude-parchment-theme.yml
+++ b/registry/skins/RayYeung1989__claude-parchment-theme.yml
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/824cef053f1cabcfaca93ae6b63261f66279f238/RayYeung1989/claude-parchment-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -50,3 +49,4 @@ releaseUpdatedAt: 2026-08-16T13:53:45.052Z
 metadataUpdatedAt: 2026-08-18T15:43:27.543Z
 starsUpdatedAt: 2026-08-16T13:53:45.052Z
 updatedAt: 2026-08-18T15:43:27.543Z
+marketScreenshots: []

--- a/registry/skins/ReLuckyLucy__dsh_Rhine_Lab_themo.yml
+++ b/registry/skins/ReLuckyLucy__dsh_Rhine_Lab_themo.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh_Rhine_Lab_themo
   en: dsh_Rhine_Lab_themo
 author: ReLuckyLucy
-description: English | 中文
+description: Arknights Rhine Lab archive-terminal reconstruction for the DeepSeek Harness Web GUI, with reversible deep styling and restrained institutional HUD
 repo: https://github.com/ReLuckyLucy/dsh_Rhine_Lab_themo
 package: dsh-theme-rhine-lab
 rowId: ui-theme-rhine-lab
@@ -46,6 +46,6 @@ license:
 featuredRank: 118
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:48.008Z
-metadataUpdatedAt: 2026-08-19T04:40:48.350Z
+metadataUpdatedAt: 2026-08-18T15:45:48.008Z
 starsUpdatedAt: 2026-08-16T13:57:12.755Z
-updatedAt: 2026-08-19T04:40:48.350Z
+updatedAt: 2026-08-18T15:45:48.008Z

--- a/registry/skins/RevolutionLA__dsh-dream-skin.yml
+++ b/registry/skins/RevolutionLA__dsh-dream-skin.yml
@@ -44,8 +44,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 4
-starsSnapshot: 58
+starsSnapshot: 57
 releaseUpdatedAt: 2026-08-18T15:38:55.099Z
 metadataUpdatedAt: 2026-08-18T15:38:55.099Z
-starsUpdatedAt: 2026-08-19T04:33:16.844Z
-updatedAt: 2026-08-19T04:33:16.844Z
+starsUpdatedAt: 2026-08-18T15:38:55.099Z
+updatedAt: 2026-08-18T15:38:55.099Z

--- a/registry/skins/Sim-xia__dsh-vscode-theme.yml
+++ b/registry/skins/Sim-xia__dsh-vscode-theme.yml
@@ -23,8 +23,7 @@ compatibility:
   dsh: ">=0.0.1-rc.1"
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/1e22fa74783f5f84e7ecb8d7b96fb2997dc9d4f8/Sim-xia/dsh-vscode-theme
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -48,3 +47,4 @@ releaseUpdatedAt: 2026-08-16T12:17:02.328Z
 metadataUpdatedAt: 2026-08-18T15:43:34.062Z
 starsUpdatedAt: 2026-08-18T15:43:34.062Z
 updatedAt: 2026-08-18T15:43:34.062Z
+marketScreenshots: []

--- a/registry/skins/Small-tailqwq__dsh-deep-whale--maid-atelier.yml
+++ b/registry/skins/Small-tailqwq__dsh-deep-whale--maid-atelier.yml
@@ -20,9 +20,9 @@ modes:
   - light
   - dark
 install:
-  target: github:Small-tailqwq/dsh-deep-whale#6ce114cf67c785e61458d30d2ea53f7d0ea95bbe&path:maid-atelier
+  target: github:Small-tailqwq/dsh-deep-whale#fd595d9244a26d14f739ca8c6e925bd559a0c768&path:maid-atelier
   version: 0.0.1
-  commit: 6ce114cf67c785e61458d30d2ea53f7d0ea95bbe
+  commit: fd595d9244a26d14f739ca8c6e925bd559a0c768
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
@@ -50,8 +50,8 @@ license:
   commercialUse: false
   notice: 仅限非商业使用；详情页必须保留原仓库 NOTICE 署名链。
 featuredRank: 2
-starsSnapshot: 1400
-releaseUpdatedAt: 2026-08-19T04:32:58.111Z
+starsSnapshot: 1353
+releaseUpdatedAt: 2026-08-18T15:38:13.458Z
 metadataUpdatedAt: 2026-08-18T15:38:13.458Z
-starsUpdatedAt: 2026-08-19T04:32:58.111Z
-updatedAt: 2026-08-19T04:32:58.111Z
+starsUpdatedAt: 2026-08-18T15:38:13.458Z
+updatedAt: 2026-08-18T15:38:13.458Z

--- a/registry/skins/SnoWinKK__dsh-web-skin.yml
+++ b/registry/skins/SnoWinKK__dsh-web-skin.yml
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/d5bbefba7668c51bd28b0d13a88593ffabfa4af3/SnoWinKK/dsh-web-skin
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -49,3 +48,4 @@ releaseUpdatedAt: 2026-08-18T15:46:07.105Z
 metadataUpdatedAt: 2026-08-18T15:46:07.105Z
 starsUpdatedAt: 2026-08-18T15:46:07.105Z
 updatedAt: 2026-08-18T15:46:07.105Z
+marketScreenshots: []

--- a/registry/skins/TQSY114514__dsh-ui-appearance.yml
+++ b/registry/skins/TQSY114514__dsh-ui-appearance.yml
@@ -16,18 +16,17 @@ modes:
   - light
   - dark
 install:
-  target: github:TQSY114514/dsh-ui-appearance#f71488bf558fa962a9c0e78c4700bc9ae0504cf6
+  target: github:TQSY114514/dsh-ui-appearance#a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c
   version: 0.1.3
-  commit: f71488bf558fa962a9c0e78c4700bc9ae0504cf6
-  allowBuild: dsh-ui-appearance@https://codeload.github.com/TQSY114514/dsh-ui-appearance/tar.gz/f71488bf558fa962a9c0e78c4700bc9ae0504cf6
+  commit: a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c
+  allowBuild: dsh-ui-appearance@https://codeload.github.com/TQSY114514/dsh-ui-appearance/tar.gz/a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/f71488bf558fa962a9c0e78c4700bc9ae0504cf6/docs/screenshot-settings.png
-  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/f71488bf558fa962a9c0e78c4700bc9ae0504cf6/docs/screenshot-wallpaper.png
-  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/f71488bf558fa962a9c0e78c4700bc9ae0504cf6/docs/demo.gif
+  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c/docs/screenshot-settings.png
+  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c/docs/screenshot-wallpaper.png
 review:
   compatibility: unverified
   preview: verified
@@ -48,7 +47,8 @@ license:
   commercialUse: true
 featuredRank: 36
 starsSnapshot: 7
-releaseUpdatedAt: 2026-08-19T04:34:24.157Z
-metadataUpdatedAt: 2026-08-19T04:34:24.157Z
+releaseUpdatedAt: 2026-08-18T15:39:42.112Z
+metadataUpdatedAt: 2026-08-18T15:39:42.112Z
 starsUpdatedAt: 2026-08-18T15:39:42.112Z
-updatedAt: 2026-08-19T04:34:24.157Z
+updatedAt: 2026-08-18T15:39:42.112Z
+marketScreenshots: []

--- a/registry/skins/VlanTech__dsh-glassic-mist-theme.yml
+++ b/registry/skins/VlanTech__dsh-glassic-mist-theme.yml
@@ -24,8 +24,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/af4e9c3967df0fbeeead25b4f1426e30382d1a90/VlanTech/dsh-glassic-mist-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -51,3 +50,4 @@ releaseUpdatedAt: 2026-08-16T13:57:56.238Z
 metadataUpdatedAt: 2026-08-18T15:46:17.119Z
 starsUpdatedAt: 2026-08-16T13:57:56.238Z
 updatedAt: 2026-08-18T15:46:17.119Z
+marketScreenshots: []

--- a/registry/skins/WYH66666666__DSH-Transparent-UI-Plugin.yml
+++ b/registry/skins/WYH66666666__DSH-Transparent-UI-Plugin.yml
@@ -46,8 +46,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 37
-starsSnapshot: 295
+starsSnapshot: 289
 releaseUpdatedAt: 2026-08-18T15:38:18.212Z
 metadataUpdatedAt: 2026-08-18T15:38:18.212Z
-starsUpdatedAt: 2026-08-19T04:33:02.650Z
-updatedAt: 2026-08-19T04:33:02.650Z
+starsUpdatedAt: 2026-08-18T15:38:18.212Z
+updatedAt: 2026-08-18T15:38:18.212Z

--- a/registry/skins/WuWL-98__dsh-theme-paper.yml
+++ b/registry/skins/WuWL-98__dsh-theme-paper.yml
@@ -44,8 +44,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 125
-starsSnapshot: 1
+starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:58:11.377Z
 metadataUpdatedAt: 2026-08-18T15:46:27.723Z
-starsUpdatedAt: 2026-08-19T04:38:29.644Z
-updatedAt: 2026-08-19T04:38:29.644Z
+starsUpdatedAt: 2026-08-16T13:58:11.377Z
+updatedAt: 2026-08-18T15:46:27.723Z

--- a/registry/skins/X9wd09ncc__dsh-x9-theme.yml
+++ b/registry/skins/X9wd09ncc__dsh-x9-theme.yml
@@ -26,9 +26,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/X9wd09ncc/dsh-x9-theme/9af49294ab82a3ca1e6c5ab9df46179a5bd9489b//assets/screenshots/settings-theme.png
-  - https://raw.githubusercontent.com/X9wd09ncc/dsh-x9-theme/9af49294ab82a3ca1e6c5ab9df46179a5bd9489b//assets/screenshots/background.png
+screenshots: []
 review:
   compatibility: unverified
   preview: verified
@@ -52,3 +50,4 @@ releaseUpdatedAt: 2026-08-18T15:43:45.074Z
 metadataUpdatedAt: 2026-08-18T15:43:45.074Z
 starsUpdatedAt: 2026-08-16T13:54:32.014Z
 updatedAt: 2026-08-18T15:43:45.074Z
+marketScreenshots: []

--- a/registry/skins/ZRTBdSS__dsh-anime-skins.yml
+++ b/registry/skins/ZRTBdSS__dsh-anime-skins.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-anime-skins
   en: dsh-anime-skins
 author: ZRTBdSS
-description: DSH 动漫皮肤管理器：一套浏览器端插件，提供 6 种皮肤，以及配套的浮动 ☰ 菜单、会话列表分组子菜单、皮肤切换弹窗和主题化 UI 覆盖。
+description: "DSH anime skin manager: 6 skins, floating menus, session list and theme-adaptive UI overrides."
 repo: https://github.com/ZRTBdSS/dsh-anime-skins
 package: dsh-anime-skins
 rowId: dsh-anime-skins
@@ -49,6 +49,6 @@ license:
 featuredRank: 201
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:54.544Z
-metadataUpdatedAt: 2026-08-19T04:41:53.059Z
+metadataUpdatedAt: 2026-08-18T15:46:54.544Z
 starsUpdatedAt: 2026-08-18T15:46:54.544Z
-updatedAt: 2026-08-19T04:41:53.059Z
+updatedAt: 2026-08-18T15:46:54.544Z

--- a/registry/skins/a1swg1159-pixel__dsh-arcaea-theme.yml
+++ b/registry/skins/a1swg1159-pixel__dsh-arcaea-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-arcaea-theme
   en: dsh-arcaea-theme
 author: a1swg1159-pixel
-description: English | 简体中文
+description: An original Arcaea-inspired high-key prismatic UI theme plugin for DeepSeek Harness.
 repo: https://github.com/a1swg1159-pixel/dsh-arcaea-theme
 package: dsh-arcaea-theme
 rowId: arcaea-theme
@@ -45,6 +45,6 @@ license:
 featuredRank: 75
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:51:53.473Z
-metadataUpdatedAt: 2026-08-19T04:36:47.829Z
+metadataUpdatedAt: 2026-08-18T15:42:09.343Z
 starsUpdatedAt: 2026-08-16T13:51:53.473Z
-updatedAt: 2026-08-19T04:36:47.829Z
+updatedAt: 2026-08-18T15:42:09.343Z

--- a/registry/skins/ai7603__dsh-cyberpunk-theme.yml
+++ b/registry/skins/ai7603__dsh-cyberpunk-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-cyberpunk-theme
   en: dsh-cyberpunk-theme
 author: ai7603
-description: dsh-cyberpunk-theme · DSH 赛博朋克 2077 主题
+description: dsh-cyberpunk-theme
 repo: https://github.com/ai7603/dsh-cyberpunk-theme
 package: dsh-cyberpunk-theme
 rowId: cyberpunk-2077
@@ -46,6 +46,6 @@ license:
 featuredRank: 47
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16T13:48:35.219Z
-metadataUpdatedAt: 2026-08-19T04:35:07.517Z
+metadataUpdatedAt: 2026-08-18T15:40:28.030Z
 starsUpdatedAt: 2026-08-16T13:48:35.219Z
-updatedAt: 2026-08-19T04:35:07.517Z
+updatedAt: 2026-08-18T15:40:28.030Z

--- a/registry/skins/anneheartrecord__dsh-desk-pet.yml
+++ b/registry/skins/anneheartrecord__dsh-desk-pet.yml
@@ -22,8 +22,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/93c0a90e8147c53cb5d3f3f4babb75e89ebe930b/anneheartrecord/dsh-desk-pet
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -37,3 +36,4 @@ releaseUpdatedAt: 2026-08-16T13:48:42.914Z
 metadataUpdatedAt: 2026-08-16T14:18:29.509Z
 starsUpdatedAt: 2026-08-16T13:48:42.914Z
 updatedAt: 2026-08-16T14:18:29.509Z
+marketScreenshots: []

--- a/registry/skins/baihejiangnan__dsh-custom-wallpaper.yml
+++ b/registry/skins/baihejiangnan__dsh-custom-wallpaper.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-custom-wallpaper
   en: dsh-custom-wallpaper
 author: baihejiangnan
-description: DeepSeek Harness Web GUI 的自定义壁纸引擎：上传图片（客户端 WebP/JPEG 压缩）、毛玻璃模糊、面板半透明，以及自动字体颜色联动。
+description: Custom wallpaper engine for DeepSeek Harness with image compression, frosted glass, pane opacity, adaptive text colors, and optional balance display.
 repo: https://github.com/baihejiangnan/dsh-custom-wallpaper
 package: "@baihejiangnan/dsh-custom-wallpaper"
 rowId: ui-custom-wallpaper
@@ -46,6 +46,6 @@ license:
 featuredRank: 169
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:10.019Z
-metadataUpdatedAt: 2026-08-19T04:38:57.138Z
+metadataUpdatedAt: 2026-08-18T15:44:10.019Z
 starsUpdatedAt: 2026-08-18T15:44:10.019Z
-updatedAt: 2026-08-19T04:38:57.138Z
+updatedAt: 2026-08-18T15:44:10.019Z

--- a/registry/skins/bilbillm__deepseek-harness-angelina-themes.yml
+++ b/registry/skins/bilbillm__deepseek-harness-angelina-themes.yml
@@ -3,7 +3,7 @@ name:
   zh: deepseek-harness-angelina-themes
   en: deepseek-harness-angelina-themes
 author: bilbillm
-description: 把 Codex 的安洁莉娜亮色、暗色主题移植到 DeepSeek Harness 的独立 dsh-plugin。它保留 Harness 原生的对话布局和控件行为，只把视觉层替换成安洁莉娜主题：背景图、视差、磨砂玻璃、清晰的文字层级，以及在低性能或移动环境下的优雅降级。
+description: Angelina light and dark glass themes with parallax for DeepSeek Harness
 repo: https://github.com/bilbillm/deepseek-harness-angelina-themes
 package: dsh-angelina-themes
 rowId: dsh-angelina-themes
@@ -55,6 +55,6 @@ license:
 featuredRank: 58
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-18T15:40:34.001Z
-metadataUpdatedAt: 2026-08-19T04:35:14.721Z
+metadataUpdatedAt: 2026-08-18T15:40:34.001Z
 starsUpdatedAt: 2026-08-18T15:40:34.001Z
-updatedAt: 2026-08-19T04:35:14.721Z
+updatedAt: 2026-08-18T15:40:34.001Z

--- a/registry/skins/breaker505__dsh-aurora-skin.yml
+++ b/registry/skins/breaker505__dsh-aurora-skin.yml
@@ -22,8 +22,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/c594be6d1f505aa0f67ae6ea1d43ddddfc6993a4/breaker505/dsh-aurora-skin
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -47,3 +46,4 @@ releaseUpdatedAt: 2026-08-18T15:44:13.078Z
 metadataUpdatedAt: 2026-08-18T15:44:13.078Z
 starsUpdatedAt: 2026-08-18T15:44:13.078Z
 updatedAt: 2026-08-18T15:44:13.078Z
+marketScreenshots: []

--- a/registry/skins/caisiyang123__dsh-theme-dodger-17.yml
+++ b/registry/skins/caisiyang123__dsh-theme-dodger-17.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-dodger-17
   en: dsh-theme-dodger-17
 author: caisiyang123
-description: 为 DeepSeek Harness Web 界面打造的道奇蓝球场主题。
+description: "Dodger-blue ballpark theme plugin for DeepSeek Harness — day & night palettes with baseball-stitch red accents, a nod to #17"
 repo: https://github.com/caisiyang123/dsh-theme-dodger-17
 package: dsh-theme-dodger-17
 rowId: dsh-theme-dodger-17
@@ -22,8 +22,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/7ad686f0cd73e3db07418d9ea3132e38c8736989/caisiyang123/dsh-theme-dodger-17
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -45,6 +44,7 @@ license:
 featuredRank: 172
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:14.695Z
-metadataUpdatedAt: 2026-08-19T04:39:02.169Z
+metadataUpdatedAt: 2026-08-18T15:44:14.695Z
 starsUpdatedAt: 2026-08-18T15:44:14.695Z
-updatedAt: 2026-08-19T04:39:02.169Z
+updatedAt: 2026-08-18T15:44:14.695Z
+marketScreenshots: []

--- a/registry/skins/cdxDNRF__wishadel-theme.yml
+++ b/registry/skins/cdxDNRF__wishadel-theme.yml
@@ -16,17 +16,17 @@ modes:
   - light
   - dark
 install:
-  target: github:cdxDNRF/wishadel-theme#44f4bd02d737b0c3125ffdc9a1f5ecdf53ff953c
+  target: github:cdxDNRF/wishadel-theme#ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0
   version: 0.6.0
-  commit: 44f4bd02d737b0c3125ffdc9a1f5ecdf53ff953c
-  allowBuild: "@cdxdnrf/dsh-client-ui-skin-wishadel@https://codeload.github.com/cdxDNRF/wishadel-theme/tar.gz/44f4bd02d737b0c3125ffdc9a1f5ecdf53ff953c"
+  commit: ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0
+  allowBuild: "@cdxdnrf/dsh-client-ui-skin-wishadel@https://codeload.github.com/cdxDNRF/wishadel-theme/tar.gz/ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0"
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/44f4bd02d737b0c3125ffdc9a1f5ecdf53ff953c/docs/screenshots/conversation.png
-  - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/44f4bd02d737b0c3125ffdc9a1f5ecdf53ff953c/docs/screenshots/settings.png
+  - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0/docs/screenshots/conversation.png
+  - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0/docs/screenshots/settings.png
 review:
   compatibility: verified
   preview: verified
@@ -45,7 +45,7 @@ license:
   commercialUse: false
 featuredRank: 99
 starsSnapshot: 0
-releaseUpdatedAt: 2026-08-19T04:39:04.278Z
-metadataUpdatedAt: 2026-08-19T04:39:04.278Z
+releaseUpdatedAt: 2026-08-18T15:44:16.761Z
+metadataUpdatedAt: 2026-08-18T15:44:16.761Z
 starsUpdatedAt: 2026-08-16T13:54:53.805Z
-updatedAt: 2026-08-19T04:39:04.278Z
+updatedAt: 2026-08-18T15:44:16.761Z

--- a/registry/skins/chajiuqqq__dsh-claude-theme.yml
+++ b/registry/skins/chajiuqqq__dsh-claude-theme.yml
@@ -24,8 +24,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/976b65da11bd0e23d77aac9cbadd466fea51eb1b/chajiuqqq/dsh-claude-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -50,3 +49,4 @@ releaseUpdatedAt: 2026-08-16T13:50:06.363Z
 metadataUpdatedAt: 2026-08-18T15:41:24.209Z
 starsUpdatedAt: 2026-08-16T13:50:06.363Z
 updatedAt: 2026-08-18T15:41:24.209Z
+marketScreenshots: []

--- a/registry/skins/cnskycn__shuimo-skin.yml
+++ b/registry/skins/cnskycn__shuimo-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: shuimo-skin
   en: shuimo-skin
 author: cnskycn
-description: 水墨国风皮肤 (Ink-Wash Chinese-style skin) for DeepSeek Harness (dsh) Web.
+description: "????????? for DeepSeek Harness Web: rice-paper palette + ink bamboo/mountains/plum/seal decorations + falling leaves"
 repo: https://github.com/cnskycn/shuimo-skin
 package: shuimo-skin
 rowId: shuimo-skin
@@ -22,8 +22,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/6f8470414dc42541f0cfa182b0f85659cc0efc9c/cnskycn/shuimo-skin
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -45,6 +44,7 @@ license:
 featuredRank: 101
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:55:01.116Z
-metadataUpdatedAt: 2026-08-19T04:39:09.984Z
+metadataUpdatedAt: 2026-08-18T15:44:23.877Z
 starsUpdatedAt: 2026-08-16T13:55:01.116Z
-updatedAt: 2026-08-19T04:39:09.984Z
+updatedAt: 2026-08-18T15:44:23.877Z
+marketScreenshots: []

--- a/registry/skins/crack-time__dsh-web-ui-skin.yml
+++ b/registry/skins/crack-time__dsh-web-ui-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-web-ui-skin
   en: dsh-web-ui-skin
 author: crack-time
-description: 田园小屋皮肤（Pastoral Cottage Skin）—— 面向 DeepSeek Harness Web GUI（dsh web）的纯 UI 换肤插件。
+description: "Pastoral Cottage skin for the DeepSeek Harness web GUI: 4K wallpaper + frosted glass panels (pure-UI dsh.client plugin)"
 repo: https://github.com/crack-time/dsh-web-ui-skin
 package: "@crack/dsh-web-ui-skin"
 rowId: dsh-web-ui-skin
@@ -45,6 +45,6 @@ license:
 featuredRank: 174
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:25.553Z
-metadataUpdatedAt: 2026-08-19T04:39:11.410Z
+metadataUpdatedAt: 2026-08-18T15:44:25.553Z
 starsUpdatedAt: 2026-08-18T15:44:25.553Z
-updatedAt: 2026-08-19T04:39:11.410Z
+updatedAt: 2026-08-18T15:44:25.553Z

--- a/registry/skins/d-dev0101__open-sea-skin.yml
+++ b/registry/skins/d-dev0101__open-sea-skin.yml
@@ -18,19 +18,19 @@ modes:
   - light
   - dark
 install:
-  target: github:d-dev0101/open-sea-skin#2437d80a96de4124c54fbe89872fa7090103f025
+  target: github:d-dev0101/open-sea-skin#5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2
   version: 1.2.1
-  commit: 2437d80a96de4124c54fbe89872fa7090103f025
+  commit: 5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/marketplace/open-sea-harness-cover.png
-  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-dark-overview-40.gif
-  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-light-overview-40.gif
-  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-wave-control-40.gif
-  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-daylight-sunset-40.gif
+  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/marketplace/open-sea-harness-cover.png
+  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/screenshots/harness-dark-overview-40.gif
+  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/screenshots/harness-light-overview-40.gif
+  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/screenshots/harness-wave-control-40.gif
+  - https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/screenshots/harness-daylight-sunset-40.gif
 review:
   compatibility: verified
   preview: verified
@@ -49,8 +49,8 @@ license:
   commercialUse: true
   notice: Includes vendored three.js under MIT and Geist fonts under SIL OFL 1.1.
 featuredRank: 0
-starsSnapshot: 177
-releaseUpdatedAt: 2026-08-19T04:33:06.048Z
-metadataUpdatedAt: 2026-08-19T04:33:06.048Z
-starsUpdatedAt: 2026-08-19T04:33:06.048Z
-updatedAt: 2026-08-19T04:33:06.048Z
+starsSnapshot: 1
+releaseUpdatedAt: 2026-08-18T15:42:28.760Z
+metadataUpdatedAt: 2026-08-18T15:42:28.760Z
+starsUpdatedAt: 2026-08-18T15:42:28.760Z
+updatedAt: 2026-08-18T15:42:28.760Z

--- a/registry/skins/ddbj-hub__dsh-wallpaper-skin.yml
+++ b/registry/skins/ddbj-hub__dsh-wallpaper-skin.yml
@@ -25,8 +25,7 @@ compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/75bd37fe0846a676b05d0cf0d816cf7f9b04c3c7/ddbj-hub/dsh-wallpaper-skin
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -50,3 +49,4 @@ releaseUpdatedAt: 2026-08-18T15:41:28.329Z
 metadataUpdatedAt: 2026-08-18T15:41:28.329Z
 starsUpdatedAt: 2026-08-18T15:41:28.329Z
 updatedAt: 2026-08-18T15:41:28.329Z
+marketScreenshots: []

--- a/registry/skins/dlpufan__dsh-theme-cyberpunk.yml
+++ b/registry/skins/dlpufan__dsh-theme-cyberpunk.yml
@@ -25,8 +25,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/0bddb1507514e758f1f63668df2b0c90d8d20102/dlpufan/dsh-theme-cyberpunk
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -51,3 +50,4 @@ releaseUpdatedAt: 2026-08-16T13:50:20.382Z
 metadataUpdatedAt: 2026-08-18T15:41:29.736Z
 starsUpdatedAt: 2026-08-16T13:50:20.382Z
 updatedAt: 2026-08-18T15:41:29.736Z
+marketScreenshots: []

--- a/registry/skins/gooosie__dsh-whale-bg.yml
+++ b/registry/skins/gooosie__dsh-whale-bg.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-whale-bg
   en: dsh-whale-bg
 author: gooosie
-description: English | 简体中文
+description: Unofficial DeepSeek Harness particle-whale background plugin with cursor lighting and theme support.
 repo: https://github.com/gooosie/dsh-whale-bg
 package: dsh-whale-bg
 rowId: whale-bg
@@ -48,6 +48,6 @@ license:
 featuredRank: 104
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:45.240Z
-metadataUpdatedAt: 2026-08-19T04:39:34.354Z
+metadataUpdatedAt: 2026-08-18T15:44:45.240Z
 starsUpdatedAt: 2026-08-16T13:55:34.455Z
-updatedAt: 2026-08-19T04:39:34.354Z
+updatedAt: 2026-08-18T15:44:45.240Z

--- a/registry/skins/hanyi7867069-create__dsh-moonrise.yml
+++ b/registry/skins/hanyi7867069-create__dsh-moonrise.yml
@@ -21,8 +21,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/4e8029680754eafa5fa738fea3f03ac2c605c138/hanyi7867069-create/dsh-moonrise
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -47,3 +46,4 @@ releaseUpdatedAt: 2026-08-18T15:44:51.312Z
 metadataUpdatedAt: 2026-08-18T15:44:51.312Z
 starsUpdatedAt: 2026-08-18T15:44:51.312Z
 updatedAt: 2026-08-18T15:44:51.312Z
+marketScreenshots: []

--- a/registry/skins/hyposelen1a__dsh-columbina-theme.yml
+++ b/registry/skins/hyposelen1a__dsh-columbina-theme.yml
@@ -17,16 +17,16 @@ modes:
   - light
   - dark
 install:
-  target: github:hyposelen1a/dsh-columbina-theme#2ccf33d427347f0dbf5004eb182f99182ee3c94e
-  version: 0.1.1
-  commit: 2ccf33d427347f0dbf5004eb182f99182ee3c94e
+  target: github:hyposelen1a/dsh-columbina-theme#00b8e72e5d40bbaf62959e5a5bef5108beded9e0
+  version: 0.1.0
+  commit: 00b8e72e5d40bbaf62959e5a5bef5108beded9e0
 compatibility:
   dsh: 0.1.0-rc.7
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/docs/screenshot-light.png
-  - https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/docs/screenshot-dark.png
+  - https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/00b8e72e5d40bbaf62959e5a5bef5108beded9e0/docs/screenshot-light.png
+  - https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/00b8e72e5d40bbaf62959e5a5bef5108beded9e0/docs/screenshot-dark.png
 review:
   compatibility: verified
   preview: verified
@@ -45,7 +45,7 @@ license:
   commercialUse: true
 featuredRank: 160
 starsSnapshot: 1
-releaseUpdatedAt: 2026-08-19T04:37:18.272Z
-metadataUpdatedAt: 2026-08-19T04:37:18.272Z
+releaseUpdatedAt: 2026-08-18T15:42:41.150Z
+metadataUpdatedAt: 2026-08-18T15:42:41.150Z
 starsUpdatedAt: 2026-08-18T15:42:41.150Z
-updatedAt: 2026-08-19T04:37:18.272Z
+updatedAt: 2026-08-18T15:42:41.150Z

--- a/registry/skins/ink5897__dsh-theme-kit.yml
+++ b/registry/skins/ink5897__dsh-theme-kit.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-kit
   en: dsh-theme-kit
 author: ink5897
-description: English | 中文
+description: "A DeepSeek Harness Web GUI appearance kit: 32 preset themes, animated/static wallpapers, paper textures, per-zone text depth, and a keyboard desktop pet."
 repo: https://github.com/ink5897/dsh-theme-kit
 package: dsh-theme-kit
 rowId: theme-kit
@@ -51,6 +51,6 @@ license:
 featuredRank: 80
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:52:31.430Z
-metadataUpdatedAt: 2026-08-19T04:37:22.717Z
+metadataUpdatedAt: 2026-08-18T15:42:45.831Z
 starsUpdatedAt: 2026-08-16T13:52:31.430Z
-updatedAt: 2026-08-19T04:37:22.717Z
+updatedAt: 2026-08-18T15:42:45.831Z

--- a/registry/skins/jungeer__dsh-theme-stardew.yml
+++ b/registry/skins/jungeer__dsh-theme-stardew.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-stardew
   en: dsh-theme-stardew
 author: jungeer
-description: 面向 DeepSeek Harness Web 端的 《星露谷物语》主题客户端插件。把整站 UI 换成温暖的像素农场风（聊天气泡、侧栏 Logo、农舍配色、代码绘制场景、昼夜氛围）——非商业同人作品。
+description: dsh-theme-stardew
 repo: https://github.com/jungeer/dsh-theme-stardew
 package: dsh-theme-stardew
 rowId: theme-stardew
@@ -46,6 +46,6 @@ license:
 featuredRank: 161
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:49.178Z
-metadataUpdatedAt: 2026-08-19T04:37:25.870Z
+metadataUpdatedAt: 2026-08-18T15:42:49.178Z
 starsUpdatedAt: 2026-08-18T15:42:49.178Z
-updatedAt: 2026-08-19T04:37:25.870Z
+updatedAt: 2026-08-18T15:42:49.178Z

--- a/registry/skins/justintangsysu__dsh-amadeus-skin.yml
+++ b/registry/skins/justintangsysu__dsh-amadeus-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-amadeus-skin
   en: dsh-amadeus-skin
 author: justintangsysu
-description: DeepSeek Harness Web 的 Steins;Gate 0 / Amadeus 风格主题皮肤。
+description: Steins;Gate 0 / Amadeus inspired skin for DeepSeek Harness Web.
 repo: https://github.com/justintangsysu/dsh-amadeus-skin
 package: "@dsh-external/dsh-client-ui-skin-amadeus"
 rowId: ui-skin-amadeus
@@ -44,6 +44,6 @@ license:
 featuredRank: 181
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:09.310Z
-metadataUpdatedAt: 2026-08-19T04:39:56.723Z
+metadataUpdatedAt: 2026-08-18T15:45:09.310Z
 starsUpdatedAt: 2026-08-18T15:45:09.310Z
-updatedAt: 2026-08-19T04:39:56.723Z
+updatedAt: 2026-08-18T15:45:09.310Z

--- a/registry/skins/kingOfSoySauce__dsh-liang-skin.yml
+++ b/registry/skins/kingOfSoySauce__dsh-liang-skin.yml
@@ -44,8 +44,8 @@ license:
   commercialUse: false
   notice: 仓库当前未声明许可证；安装和再分发前请向作者确认授权。
 featuredRank: 1
-starsSnapshot: 103
+starsSnapshot: 97
 releaseUpdatedAt: 2026-08-18T15:38:29.706Z
 metadataUpdatedAt: 2026-08-18T15:38:29.706Z
-starsUpdatedAt: 2026-08-19T04:33:09.242Z
-updatedAt: 2026-08-19T04:33:09.242Z
+starsUpdatedAt: 2026-08-18T15:38:29.706Z
+updatedAt: 2026-08-18T15:38:29.706Z

--- a/registry/skins/kingOfSoySauce__dsh-musk-skin.yml
+++ b/registry/skins/kingOfSoySauce__dsh-musk-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: 马斯克强度
   en: Musk Intensity Skin
 author: kingOfSoySauce
-description: 滑动变祖 · 马圣 · DeepSeek Harness 皮肤
+description: dsh-elon-skin
 repo: https://github.com/kingOfSoySauce/dsh-elon-skin
 package: dsh-client-musk-intensity-skin
 rowId: musk-intensity-skin
@@ -49,6 +49,6 @@ license:
 featuredRank: 2
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:53.218Z
-metadataUpdatedAt: 2026-08-19T04:37:30.325Z
+metadataUpdatedAt: 2026-08-18T15:42:53.218Z
 starsUpdatedAt: 2026-08-18T09:15:01.000Z
-updatedAt: 2026-08-19T04:37:30.325Z
+updatedAt: 2026-08-18T15:42:53.218Z

--- a/registry/skins/kongxiangyiren__dhs-theme-plugin.yml
+++ b/registry/skins/kongxiangyiren__dhs-theme-plugin.yml
@@ -23,8 +23,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/9e451e3a9eda86f62c8624d606a911e68a943b16/kongxiangyiren/dhs-theme-plugin
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -48,3 +47,4 @@ releaseUpdatedAt: 2026-08-16T13:52:44.893Z
 metadataUpdatedAt: 2026-08-18T15:42:56.068Z
 starsUpdatedAt: 2026-08-16T13:52:44.893Z
 updatedAt: 2026-08-18T15:42:56.068Z
+marketScreenshots: []

--- a/registry/skins/lkdx0220__Genshin-odette-skin-dsh.yml
+++ b/registry/skins/lkdx0220__Genshin-odette-skin-dsh.yml
@@ -3,7 +3,7 @@ name:
   zh: Genshin-odette-skin-dsh
   en: Genshin-odette-skin-dsh
 author: lkdx0220
-description: Odette 冰雪梦幻主题 —— DSH 客户端的深/浅双模式 UI 美化皮肤。
+description: Genshin-odette-skin-dsh
 repo: https://github.com/lkdx0220/Genshin-odette-skin-dsh
 package: dsh-odette-skin
 rowId: odette-skin
@@ -51,6 +51,6 @@ license:
 featuredRank: 182
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:23.237Z
-metadataUpdatedAt: 2026-08-19T04:40:15.309Z
+metadataUpdatedAt: 2026-08-18T15:45:23.237Z
 starsUpdatedAt: 2026-08-18T15:45:23.237Z
-updatedAt: 2026-08-19T04:40:15.309Z
+updatedAt: 2026-08-18T15:45:23.237Z

--- a/registry/skins/longyu065__dsh-theme-ti.yml
+++ b/registry/skins/longyu065__dsh-theme-ti.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-ti
   en: dsh-theme-ti
 author: longyu065
-description: English · 中文
+description: dsh-theme-ti
 repo: https://github.com/longyu065/dsh-theme-ti
 package: "@dsh-theme/ti"
 rowId: theme-ti
@@ -18,15 +18,14 @@ modes:
   - light
   - dark
 install:
-  target: github:longyu065/dsh-theme-ti#62ae2e761f045387617e28828e4b533626b3156e
+  target: github:longyu065/dsh-theme-ti#b6b54db83aadbf8d67f3482f3b864e67f98bf73b
   version: 1.0.0
-  commit: 62ae2e761f045387617e28828e4b533626b3156e
+  commit: b6b54db83aadbf8d67f3482f3b864e67f98bf73b
 compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/62ae2e761f045387617e28828e4b533626b3156e/longyu065/dsh-theme-ti
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -47,7 +46,8 @@ license:
   commercialUse: true
 featuredRank: 84
 starsSnapshot: 1
-releaseUpdatedAt: 2026-08-19T04:37:44.088Z
-metadataUpdatedAt: 2026-08-19T04:37:44.088Z
+releaseUpdatedAt: 2026-08-18T15:43:04.400Z
+metadataUpdatedAt: 2026-08-18T15:43:04.400Z
 starsUpdatedAt: 2026-08-16T13:53:00.319Z
-updatedAt: 2026-08-19T04:37:44.088Z
+updatedAt: 2026-08-18T15:43:04.400Z
+marketScreenshots: []

--- a/registry/skins/lssyd20070106__dsh-ui-preset-enhance.yml
+++ b/registry/skins/lssyd20070106__dsh-ui-preset-enhance.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-ui-preset-enhance
   en: dsh-ui-preset-enhance
 author: lssyd20070106
-description: 简体中文 · English · 小白安装手册
+description: "Third-party DSH WebUI enhancement plugin: custom backgrounds, theme colors, prompt presets, token/context visibility, and manual compact."
 repo: https://github.com/lssyd20070106/dsh-ui-preset-enhance
 package: dsh-ui-preset-enhance
 rowId: dsh-ui-preset-enhance
@@ -45,6 +45,6 @@ license:
 featuredRank: 42
 starsSnapshot: 7
 releaseUpdatedAt: 2026-08-16T13:47:45.102Z
-metadataUpdatedAt: 2026-08-19T04:34:19.952Z
+metadataUpdatedAt: 2026-08-18T15:39:35.097Z
 starsUpdatedAt: 2026-08-18T15:39:35.097Z
-updatedAt: 2026-08-19T04:34:19.952Z
+updatedAt: 2026-08-18T15:39:35.097Z

--- a/registry/skins/lzylyd__dsh-dracula.yml
+++ b/registry/skins/lzylyd__dsh-dracula.yml
@@ -22,8 +22,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/d03495118b21019a9e45f63044985faf6962e5f6/lzylyd/dsh-dracula
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -48,3 +47,4 @@ releaseUpdatedAt: 2026-08-16T13:53:10.751Z
 metadataUpdatedAt: 2026-08-18T15:43:09.134Z
 starsUpdatedAt: 2026-08-16T13:53:10.751Z
 updatedAt: 2026-08-18T15:43:09.134Z
+marketScreenshots: []

--- a/registry/skins/makuralymi__dsh-webUI-Glass-Theme.yml
+++ b/registry/skins/makuralymi__dsh-webUI-Glass-Theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-webUI-Glass-Theme
   en: dsh-webUI-Glass-Theme
 author: makuralymi
-description: 为 dsh Web UI 提供的全局毛玻璃（frosted glass / backdrop blur）主题插件。它不改变现有浅色/深色偏好，而是在任意主题之上叠加一层半透明表面 token 覆盖与全局 backdrop-filter 模糊，让整个界面呈现 iOS/macOS 风格的磨砂玻璃质感。
+description: dsh-webUI-Glass-Theme
 repo: https://github.com/makuralymi/dsh-webUI-Glass-Theme
 package: dsh-client-ui-frosted-glass
 rowId: ui-frosted-glass
@@ -46,6 +46,6 @@ license:
 featuredRank: 53
 starsSnapshot: 4
 releaseUpdatedAt: 2026-08-18T15:40:20.925Z
-metadataUpdatedAt: 2026-08-19T04:35:03.738Z
+metadataUpdatedAt: 2026-08-18T15:40:20.925Z
 starsUpdatedAt: 2026-08-18T15:40:20.925Z
-updatedAt: 2026-08-19T04:35:03.738Z
+updatedAt: 2026-08-18T15:40:20.925Z

--- a/registry/skins/mizuhara37__dsh-nene-theme.yml
+++ b/registry/skins/mizuhara37__dsh-nene-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-nene-theme
   en: dsh-nene-theme
 author: mizuhara37
-description: 草薙宁宁主题 · Nene Theme（DeepSeek Harness 客户端插件）
+description: dsh-nene-theme
 repo: https://github.com/mizuhara37/dsh-nene-theme
 package: dsh-nene-theme
 rowId: nene-theme
@@ -26,8 +26,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/dcf7642211a84114186a7f12e1a6efbe5d7d36e1/mizuhara37/dsh-nene-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -50,6 +49,7 @@ license:
 featuredRank: 114
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:29.292Z
-metadataUpdatedAt: 2026-08-19T04:40:24.246Z
+metadataUpdatedAt: 2026-08-18T15:45:29.292Z
 starsUpdatedAt: 2026-08-16T13:56:45.550Z
-updatedAt: 2026-08-19T04:40:24.246Z
+updatedAt: 2026-08-18T15:45:29.292Z
+marketScreenshots: []

--- a/registry/skins/mldhao__dsh-blue-archive-shiroko.yml
+++ b/registry/skins/mldhao__dsh-blue-archive-shiroko.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-blue-archive-shiroko
   en: dsh-blue-archive-shiroko
 author: mldhao
-description: 简体中文 · English
+description: Blue Archive-inspired DSH theme with a Shiroko desktop companion, Codex-style reply bubbles, petting effects, and completion chime.
 repo: https://github.com/mldhao/dsh-blue-archive-shiroko
 package: dsh-blue-archive-shiroko
 rowId: blue-archive-shiroko
@@ -24,8 +24,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/mldhao/dsh-blue-archive-shiroko/dffeebce96a606c22cf593be3affbf6620e91a9b/assets/screenshot.png
+screenshots: []
 review:
   compatibility: unverified
   preview: verified
@@ -46,6 +45,7 @@ license:
 featuredRank: 86
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:22.631Z
-metadataUpdatedAt: 2026-08-19T04:37:56.159Z
+metadataUpdatedAt: 2026-08-18T15:43:15.042Z
 starsUpdatedAt: 2026-08-16T13:53:22.631Z
-updatedAt: 2026-08-19T04:37:56.159Z
+updatedAt: 2026-08-18T15:43:15.042Z
+marketScreenshots: []

--- a/registry/skins/mtaech__dsh-material-you.yml
+++ b/registry/skins/mtaech__dsh-material-you.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-material-you
   en: dsh-material-you
 author: mtaech
-description: Material You 皮肤 · DeepSeek Harness
+description: "Material You (M3) skin for DeepSeek Harness: HCT tonal palette + Maple Mono NF CN, clean blue & white"
 repo: https://github.com/mtaech/dsh-material-you
 package: "@deepseek-ai/dsh-skin-material-you"
 rowId: ui-skin-material-you
@@ -45,6 +45,6 @@ license:
 featuredRank: 87
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:28.039Z
-metadataUpdatedAt: 2026-08-19T04:37:58.290Z
+metadataUpdatedAt: 2026-08-18T15:43:16.621Z
 starsUpdatedAt: 2026-08-16T13:53:28.039Z
-updatedAt: 2026-08-19T04:37:58.290Z
+updatedAt: 2026-08-18T15:43:16.621Z

--- a/registry/skins/nexsjournal__dsh-customui-plugin.yml
+++ b/registry/skins/nexsjournal__dsh-customui-plugin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-customui-plugin
   en: dsh-customui-plugin
 author: nexsjournal
-description: dsh-customui-plugin（个性化）
+description: "Personalize the DeepSeek Harness web GUI: sidebar logo, empty-conversation hero, and chat background image — applied live, no restart"
 repo: https://github.com/nexsjournal/dsh-customui-plugin
 package: dsh-customui-plugin
 rowId: dsh-customui-plugin
@@ -22,8 +22,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/51b95efd50b468606833d1fbb918adb028fe6b1e/nexsjournal/dsh-customui-plugin
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -45,6 +44,7 @@ license:
 featuredRank: 164
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:43:20.066Z
-metadataUpdatedAt: 2026-08-19T04:38:02.365Z
+metadataUpdatedAt: 2026-08-18T15:43:20.066Z
 starsUpdatedAt: 2026-08-18T15:43:20.066Z
-updatedAt: 2026-08-19T04:38:02.365Z
+updatedAt: 2026-08-18T15:43:20.066Z
+marketScreenshots: []

--- a/registry/skins/niiang__dsh-kimino-theme.yml
+++ b/registry/skins/niiang__dsh-kimino-theme.yml
@@ -18,17 +18,17 @@ modes:
   - light
   - dark
 install:
-  target: github:niiang/dsh-kimino-theme#0a17159ecc9cf61834bac3265f5c8dab333431e9
+  target: github:niiang/dsh-kimino-theme#eda0aef6141cf13e4bb123a4749696fe045c349c
   version: 66.1.0
-  commit: 0a17159ecc9cf61834bac3265f5c8dab333431e9
+  commit: eda0aef6141cf13e4bb123a4749696fe045c349c
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/home-hero.png
-  - https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/sidebar.png
-  - https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/chat-main.png
+  - https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/home-hero.png
+  - https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/sidebar.png
+  - https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/chat-main.png
 review:
   compatibility: unverified
   preview: verified
@@ -47,8 +47,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 145
-starsSnapshot: 10
-releaseUpdatedAt: 2026-08-19T04:34:04.542Z
-metadataUpdatedAt: 2026-08-19T04:34:04.542Z
-starsUpdatedAt: 2026-08-19T04:34:04.542Z
-updatedAt: 2026-08-19T04:34:04.542Z
+starsSnapshot: 9
+releaseUpdatedAt: 2026-08-18T15:39:49.952Z
+metadataUpdatedAt: 2026-08-18T15:39:49.952Z
+starsUpdatedAt: 2026-08-18T15:39:49.952Z
+updatedAt: 2026-08-18T15:39:49.952Z

--- a/registry/skins/nineandnine-9__dsh-theme-rheostat.yml
+++ b/registry/skins/nineandnine-9__dsh-theme-rheostat.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-rheostat
   en: dsh-theme-rheostat
 author: nineandnine-9
-description: 滑动变阻器 · dsh-theme-rheostat
+description: "Sliding-rheostat theme plugin for the DeepSeek Harness web GUI: model + reasoning-effort driven accents, composer glow, and a whale slider."
 repo: https://github.com/nineandnine-9/dsh-theme-rheostat
 package: "@dsh-external/dsh-theme-rheostat"
 rowId: ui-theme-rheostat
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/f535e6817e4ac0c2a78f383adf4943f5807b88b4/nineandnine-9/dsh-theme-rheostat
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -46,6 +45,7 @@ license:
 featuredRank: 88
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:31.745Z
-metadataUpdatedAt: 2026-08-19T04:38:04.836Z
+metadataUpdatedAt: 2026-08-18T15:43:22.841Z
 starsUpdatedAt: 2026-08-16T13:53:31.745Z
-updatedAt: 2026-08-19T04:38:04.836Z
+updatedAt: 2026-08-18T15:43:22.841Z
+marketScreenshots: []

--- a/registry/skins/nlqh7__dsh-beautify.yml
+++ b/registry/skins/nlqh7__dsh-beautify.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-beautify
   en: dsh-beautify
 author: nlqh7
-description: DeepSeek Harness 完整美化包：本地主题换肤（不联网）+ Wallpaper Engine 动态壁纸 + 自定义主题，一个插件搞定，设置页统一管理。
+description: "DeepSeek Harness Dream Skin，DSH theme plugin: Dream Skin color presets with a settings-page switcher."
 repo: https://github.com/nlqh7/dsh-beautify
 package: "@deepseek-ai/dsh-beautify"
 rowId: dsh-beautify
@@ -25,8 +25,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/05eb9813cec758fb756ec8011d62218744455e5b/nlqh7/dsh-beautify
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -48,6 +47,7 @@ license:
 featuredRank: 184
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:34.008Z
-metadataUpdatedAt: 2026-08-19T04:40:31.950Z
+metadataUpdatedAt: 2026-08-18T15:45:34.008Z
 starsUpdatedAt: 2026-08-18T15:45:34.008Z
-updatedAt: 2026-08-19T04:40:31.950Z
+updatedAt: 2026-08-18T15:45:34.008Z
+marketScreenshots: []

--- a/registry/skins/noexcs__dsh-skin-glass.yml
+++ b/registry/skins/noexcs__dsh-skin-glass.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-skin-glass
   en: dsh-skin-glass
 author: noexcs
-description: 给 DeepSeek Harness（DSH）Web GUI 换肤的毛玻璃皮肤插件。
+description: "Frosted-glass skin for the DeepSeek Harness web UI: pick any image as background, theme colors extracted from it, glassmorphism surfaces."
 repo: https://github.com/noexcs/dsh-skin-glass
 package: dsh-skin-glass
 rowId: dsh-skin-glass
@@ -47,6 +47,6 @@ license:
 featuredRank: 116
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:56:56.643Z
-metadataUpdatedAt: 2026-08-19T04:40:34.350Z
+metadataUpdatedAt: 2026-08-18T15:45:35.434Z
 starsUpdatedAt: 2026-08-16T13:56:56.643Z
-updatedAt: 2026-08-19T04:40:34.350Z
+updatedAt: 2026-08-18T15:45:35.434Z

--- a/registry/skins/oceanxuikun__dsh-eva-theme-plugin.yml
+++ b/registry/skins/oceanxuikun__dsh-eva-theme-plugin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-eva-theme-plugin
   en: dsh-eva-theme-plugin
 author: oceanxuikun
-description: English | 中文
+description: Evangelion-inspired theme plugin for DSH WebUI, featuring Unit-00, Unit-01, and Unit-02 themes with immersive backgrounds and mecha-style UI effects.
 repo: https://github.com/oceanxuikun/dsh-eva-theme-plugin
 package: dsh-eva-theme-plugin
 rowId: dsh-eva-theme-plugin
@@ -49,6 +49,6 @@ license:
 featuredRank: 89
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:35.278Z
-metadataUpdatedAt: 2026-08-19T04:38:06.482Z
+metadataUpdatedAt: 2026-08-18T15:43:24.304Z
 starsUpdatedAt: 2026-08-16T13:53:35.278Z
-updatedAt: 2026-08-19T04:38:06.482Z
+updatedAt: 2026-08-18T15:43:24.304Z

--- a/registry/skins/rison114514__dsh-endfield-ui.yml
+++ b/registry/skins/rison114514__dsh-endfield-ui.yml
@@ -25,10 +25,6 @@ compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/home.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/conversation.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/settings.png
 screenshots:
   - https://raw.githubusercontent.com/rison114514/dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/dsh-packaged-final.jpg
   - https://raw.githubusercontent.com/rison114514/dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/dsh-settings-final.jpg
@@ -40,20 +36,24 @@ health:
   status: improvements
   checks:
     readmeScreenshots: improve
-    compatibility: improve
+    compatibility: pass
     installation: pass
     installCommand: pass
     topic: pass
   suggestions:
-    - 建议在 README 中加入至少一张仓库内的真实界面截图，并让图片路径随仓库一起版本化，方便用户预览和市场稳定展示。
-    - 建议在 README 或 package.json 中明确声明支持的 DSH Web 版本范围（例如 0.1.0-rc.6 或兼容区间），方便用户在安装前确认环境。
+    - 建议在 endfield-ui-plugin/README.md 中嵌入至少一张固定版本的 DSH Web 实机运行截图，方便用户直接确认主题效果。
+    - 建议为随包分发的 Harmony、Novecento、Space Grotesk 字体和第三方视觉素材补充可核验的许可证文件或再分发说明。
 license:
   code: MIT
-  commercialUse: true
+  commercialUse: false
   notice: 插件代码在 package.json 中声明为 MIT；仓库同时说明第三方字体、游戏视觉素材和品牌/角色素材的授权范围仍需逐项确认，因此市场不将整体素材视为可商业再分发。
 featuredRank: 143
-starsSnapshot: 10
+starsSnapshot: 9
 releaseUpdatedAt: 2026-08-18T15:57:53.000Z
-metadataUpdatedAt: 2026-08-19T04:34:08.976Z
-starsUpdatedAt: 2026-08-19T04:34:08.976Z
-updatedAt: 2026-08-19T04:34:08.976Z
+metadataUpdatedAt: 2026-08-18T16:23:45.180Z
+starsUpdatedAt: 2026-08-18T15:57:53.000Z
+updatedAt: 2026-08-18T16:23:45.180Z
+marketScreenshots:
+  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/home.png
+  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/conversation.png
+  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/settings.png

--- a/registry/skins/sakka6868__dsh-skin.yml
+++ b/registry/skins/sakka6868__dsh-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-skin
   en: dsh-skin
 author: sakka6868
-description: English | 中文
+description: "DSH skin plugin: Alphacoders popular wallpapers as the DeepSeek Harness Web GUI background — gallery, search, local image upload, light/dark mask"
 repo: https://github.com/sakka6868/dsh-skin
 package: dsh-skin-alphacoders
 rowId: skin-alphacoders
@@ -46,6 +46,6 @@ license:
 featuredRank: 92
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:53:50.782Z
-metadataUpdatedAt: 2026-08-19T04:36:28.388Z
+metadataUpdatedAt: 2026-08-18T15:41:48.437Z
 starsUpdatedAt: 2026-08-18T15:41:48.437Z
-updatedAt: 2026-08-19T04:36:28.388Z
+updatedAt: 2026-08-18T15:41:48.437Z

--- a/registry/skins/seekerwxy__dsh-aurora-theme.yml
+++ b/registry/skins/seekerwxy__dsh-aurora-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-aurora-theme
   en: dsh-aurora-theme
 author: seekerwxy
-description: DeepSeek Harness（DSH）Web 界面的深黑冷色调主题插件：深邃蓝黑底、电光青强调色，配上星网 + 极光 + 细网格背景，并在设置面板内置「主题设置」页——可一键 开启/关闭 主题，也可切换背景模式（动态 / 静态）。
+description: DSH ????:??????? + ??/???? + ??/??????
 repo: https://github.com/seekerwxy/dsh-aurora-theme
 package: dsh-aurora-theme
 rowId: aurora-theme
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/3b220e179812a81e60f2d32259bde9262808cd09/seekerwxy/dsh-aurora-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -47,6 +46,7 @@ license:
 featuredRank: 119
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:57:29.957Z
-metadataUpdatedAt: 2026-08-19T04:40:56.223Z
+metadataUpdatedAt: 2026-08-18T15:45:58.101Z
 starsUpdatedAt: 2026-08-16T13:57:29.957Z
-updatedAt: 2026-08-19T04:40:56.223Z
+updatedAt: 2026-08-18T15:45:58.101Z
+marketScreenshots: []

--- a/registry/skins/shenmy-git__dsh-weather-plugin.yml
+++ b/registry/skins/shenmy-git__dsh-weather-plugin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-weather-plugin
   en: dsh-weather-plugin
 author: shenmy-git
-description: 天气工具 + 沉浸式天气主题的 DSH UI 增强插件：常驻生效，无需问答—— 页面打开即按 IP 自动定位并应用整个主页的天气效果；模型问答天气时再按回答 切换。所有组件按天气换色、全屏飘雨/飘雪/阳光/闪电氛围、一只沿页面底部游弋 的官方 FishLogo 鲸鱼宠物（右下角 HUD，可点开面板），聊天里还有带环境 音效、动植物伙伴和科普的交互卡片。
+description: "DSH plugin: weather tool + immersive weather theming + FishLogo whale pet (theme/ambient/sound/HUD)"
 repo: https://github.com/shenmy-git/dsh-weather-plugin
 package: dsh-weather-plugin
 rowId: weather
@@ -23,8 +23,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/3f94f1569a0f9193a7ff5bb7bb8000b8e6b05a36/shenmy-git/dsh-weather-plugin
+screenshots: []
 review:
   compatibility: verified
   preview: repository-card
@@ -46,6 +45,7 @@ license:
 featuredRank: 120
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:59.538Z
-metadataUpdatedAt: 2026-08-19T04:40:57.577Z
+metadataUpdatedAt: 2026-08-18T15:45:59.538Z
 starsUpdatedAt: 2026-08-16T13:57:34.783Z
-updatedAt: 2026-08-19T04:40:57.577Z
+updatedAt: 2026-08-18T15:45:59.538Z
+marketScreenshots: []

--- a/registry/skins/statem-li__dsh-reasoning-effort.yml
+++ b/registry/skins/statem-li__dsh-reasoning-effort.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-reasoning-effort
   en: dsh-reasoning-effort
 author: statem-li
-description: 中文首页现在位于 README.md。
+description: Codex-style DeepSeek Harness model and reasoning selector with model-advertised effort levels, DSH-native themes, left-c…
 repo: https://github.com/statem-li/dsh-reasoning-effort
 package: dsh-reasoning-effort
 rowId: reasoning-effort
@@ -22,10 +22,7 @@ compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/statem-li/dsh-reasoning-effort/3c0d3dd964d268fb45aa93ff8de43e7cc06429ec/assets/readme/hero.webp
-  - https://raw.githubusercontent.com/statem-li/dsh-reasoning-effort/3c0d3dd964d268fb45aa93ff8de43e7cc06429ec/assets/readme/themes.webp
-  - https://raw.githubusercontent.com/statem-li/dsh-reasoning-effort/3c0d3dd964d268fb45aa93ff8de43e7cc06429ec/assets/readme/settings.webp
+screenshots: []
 review:
   compatibility: verified
   preview: verified
@@ -45,6 +42,7 @@ license:
 featuredRank: 191
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:10.855Z
-metadataUpdatedAt: 2026-08-19T04:41:09.317Z
+metadataUpdatedAt: 2026-08-18T15:46:10.855Z
 starsUpdatedAt: 2026-08-18T15:46:10.855Z
-updatedAt: 2026-08-19T04:41:09.317Z
+updatedAt: 2026-08-18T15:46:10.855Z
+marketScreenshots: []

--- a/registry/skins/stushansusu__dsh-miku-skin.yml
+++ b/registry/skins/stushansusu__dsh-miku-skin.yml
@@ -25,9 +25,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/stushansusu/dsh-miku-skin/3a5dcacf09786820eafc1e43ee8c2603dce4b9ff/preview/light.png
-  - https://raw.githubusercontent.com/stushansusu/dsh-miku-skin/3a5dcacf09786820eafc1e43ee8c2603dce4b9ff/preview/dark.png
+screenshots: []
 review:
   compatibility: unverified
   preview: verified
@@ -41,3 +39,4 @@ releaseUpdatedAt: 2026-08-16T13:51:00.375Z
 metadataUpdatedAt: 2026-08-16T14:20:35.164Z
 starsUpdatedAt: 2026-08-16T13:51:00.375Z
 updatedAt: 2026-08-16T14:20:35.164Z
+marketScreenshots: []

--- a/registry/skins/thjyy__dph-endfield-theme.yml
+++ b/registry/skins/thjyy__dph-endfield-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dph-endfield-theme
   en: dph-endfield-theme
 author: thjyy
-description: 为 DeepSeek Harness（DSH）Web 界面制作的非官方联动主题。它保留 DSH 原有功能与文案，只改变界面配色、面板结构、交互动效，并在输入框左侧加入会随会话状态切换的角色动画。
+description: Unofficial Endfield-inspired theme and animated mascot for DeepSeek Harness Web
 repo: https://github.com/thjyy/dph-endfield-theme
 package: dph-endfield-theme
 rowId: dph-endfield-theme
@@ -50,6 +50,6 @@ license:
 featuredRank: 121
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:57:46.646Z
-metadataUpdatedAt: 2026-08-19T04:38:24.908Z
+metadataUpdatedAt: 2026-08-18T15:43:39.096Z
 starsUpdatedAt: 2026-08-18T15:43:39.096Z
-updatedAt: 2026-08-19T04:38:24.908Z
+updatedAt: 2026-08-18T15:43:39.096Z

--- a/registry/skins/tiantyu__dsh-skin-toggle.yml
+++ b/registry/skins/tiantyu__dsh-skin-toggle.yml
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/781fd4605756503f9635d6083686e079b5a8944f/tiantyu/dsh-skin-toggle
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -49,3 +48,4 @@ releaseUpdatedAt: 2026-08-18T15:40:53.638Z
 metadataUpdatedAt: 2026-08-18T15:40:53.638Z
 starsUpdatedAt: 2026-08-18T15:40:53.638Z
 updatedAt: 2026-08-18T15:40:53.638Z
+marketScreenshots: []

--- a/registry/skins/tpmoonchefryan__dsh-joi-channel-theme.yml
+++ b/registry/skins/tpmoonchefryan__dsh-joi-channel-theme.yml
@@ -47,8 +47,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 94
-starsSnapshot: 8
+starsSnapshot: 7
 releaseUpdatedAt: 2026-08-18T15:39:53.474Z
 metadataUpdatedAt: 2026-08-18T15:39:53.474Z
-starsUpdatedAt: 2026-08-19T04:34:15.062Z
-updatedAt: 2026-08-19T04:34:15.062Z
+starsUpdatedAt: 2026-08-18T15:39:53.474Z
+updatedAt: 2026-08-18T15:39:53.474Z

--- a/registry/skins/wangxilhy23__dsh-wx-skin.yml
+++ b/registry/skins/wangxilhy23__dsh-wx-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-wx-skin
   en: dsh-wx-skin
 author: wangxilhy23
-description: DeepSeek Harness（DSH）Web GUI 皮肤插件 —— 侧栏「皮肤」面板，自选本地图片或图片 URL 作为全屏磨砂背景，支持预设、暗化、模糊与透出调节，明暗主题自动适配，跨刷新持久化。
+description: dsh-wx-skin
 repo: https://github.com/wangxilhy23/dsh-wx-skin
 package: dsh-wx-skin
 rowId: ui-dsh-wx-skin
@@ -16,15 +16,15 @@ tags:
 modes:
   - dark
 install:
-  target: github:wangxilhy23/dsh-wx-skin#5351f776e73331ed70f5b656c8373c83b7a559a9
-  version: 0.1.2
-  commit: 5351f776e73331ed70f5b656c8373c83b7a559a9
+  target: github:wangxilhy23/dsh-wx-skin#1dce62c660fbc2525e1358f864dba797d2f9d5c3
+  version: 0.1.1
+  commit: 1dce62c660fbc2525e1358f864dba797d2f9d5c3
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/wangxilhy23/dsh-wx-skin/5351f776e73331ed70f5b656c8373c83b7a559a9/assets/demo1.png
+  - https://raw.githubusercontent.com/wangxilhy23/dsh-wx-skin/1dce62c660fbc2525e1358f864dba797d2f9d5c3/assets/demo1.png
 review:
   compatibility: unverified
   preview: verified
@@ -45,7 +45,7 @@ license:
   commercialUse: true
 featuredRank: 68
 starsSnapshot: 2
-releaseUpdatedAt: 2026-08-19T04:36:35.468Z
-metadataUpdatedAt: 2026-08-19T04:36:35.468Z
+releaseUpdatedAt: 2026-08-16T13:51:09.489Z
+metadataUpdatedAt: 2026-08-18T15:41:56.101Z
 starsUpdatedAt: 2026-08-16T13:51:09.489Z
-updatedAt: 2026-08-19T04:36:35.468Z
+updatedAt: 2026-08-18T15:41:56.101Z

--- a/registry/skins/webkubor__dsh-bloom-theme.yml
+++ b/registry/skins/webkubor__dsh-bloom-theme.yml
@@ -16,9 +16,9 @@ modes:
   - light
   - dark
 install:
-  target: github:webkubor/dsh-bloom-theme#5480826b1e4ce41af34a95e047290bfabc62f3a1
-  version: 0.3.4
-  commit: 5480826b1e4ce41af34a95e047290bfabc62f3a1
+  target: github:webkubor/dsh-bloom-theme#e70e6ad9ac60266323234235324cab8ac3f028ab
+  version: 0.3.3
+  commit: e70e6ad9ac60266323234235324cab8ac3f028ab
 compatibility:
   dsh: unverified
   platform:
@@ -49,7 +49,7 @@ license:
   commercialUse: true
 featuredRank: 193
 starsSnapshot: 0
-releaseUpdatedAt: 2026-08-19T04:41:18.349Z
+releaseUpdatedAt: 2026-08-18T15:46:20.380Z
 metadataUpdatedAt: 2026-08-18T15:46:20.380Z
 starsUpdatedAt: 2026-08-18T15:46:20.380Z
-updatedAt: 2026-08-19T04:41:18.349Z
+updatedAt: 2026-08-18T15:46:20.380Z

--- a/registry/skins/wensincai__dsh-skin-rotator.yml
+++ b/registry/skins/wensincai__dsh-skin-rotator.yml
@@ -1,11 +1,9 @@
 id: wensincai.dsh-skin-rotator
 name:
-  zh: åŠ¨æ€èƒŒæ™¯è½®æ’­çš®è‚¤
+  zh: 动态背景轮播皮肤
   en: dsh-skin-rotator
 author: wensincai
-description: >-
-  DSH Web åŠ¨æ€èƒŒæ™¯çš®è‚¤ï¼šæŠŠæœ¬åœ°å›¾ç‰‡ç›®å½•çš„å›¾ç‰‡æ¯ 5 åˆ†é’Ÿè½®æ’­ä¸€å¼ ä½œä¸ºå…¨å±èƒŒæ™¯ï¼Œ
-  å åŠ å¯è°ƒé»‘è‰²è’™ç‰ˆï¼Œå¹¶è‡ªåŠ¨åˆ‡æ¢æš—è‰²ä¸»é¢˜ä¿è¯æ–‡å­—å¯è¯»ã€‚
+description: DSH Web 动态背景皮肤：把本地 images/ 目录的图片每 5 分钟轮播一张作为全屏背景，叠加可调黑色蒙版，并自动切换暗色主题保证文字可读。
 repo: https://github.com/wensincai/dsh-skin-rotator
 package: dsh-skin-rotator
 rowId: skin-rotator
@@ -34,7 +32,7 @@ review:
 license:
   code: MIT
   commercialUse: true
-featuredRank: 0
+featuredRank: 1000
 starsSnapshot: 0
 releaseUpdatedAt: '2026-08-19T04:08:02.180Z'
 metadataUpdatedAt: '2026-08-19T04:08:02.180Z'

--- a/registry/skins/wuzhong962-alt__dsh-matrix-theme.yml
+++ b/registry/skins/wuzhong962-alt__dsh-matrix-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-matrix-theme
   en: dsh-matrix-theme
 author: wuzhong962-alt
-description: 黑客帝国 / 赛博朋克皮肤 —— DeepSeek Harness (DSH) Web GUI 的客户端插件。
+description: dsh-matrix-theme
 repo: https://github.com/wuzhong962-alt/dsh-matrix-theme
 package: dsh-matrix-theme
 rowId: matrix-theme
@@ -23,8 +23,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/6f451fb54d5f77359712e7fb4055fc8b025b6b68/wuzhong962-alt/dsh-matrix-theme
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -47,6 +46,7 @@ license:
 featuredRank: 95
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:54:27.004Z
-metadataUpdatedAt: 2026-08-19T04:38:31.099Z
+metadataUpdatedAt: 2026-08-18T15:43:43.537Z
 starsUpdatedAt: 2026-08-16T13:54:27.004Z
-updatedAt: 2026-08-19T04:38:31.099Z
+updatedAt: 2026-08-18T15:43:43.537Z
+marketScreenshots: []

--- a/registry/skins/xxxrickymorty-dev__dsh-rick.yml
+++ b/registry/skins/xxxrickymorty-dev__dsh-rick.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-rick
   en: dsh-rick
 author: xxxrickymorty-dev
-description: English | 中文
+description: "C-137 skin for DeepSeek Harness: 28 posters, custom scenes, and overlay pets (Rick, Morty, portal gun)."
 repo: https://github.com/xxxrickymorty-dev/dsh-rick
 package: dsh-rick
 rowId: dsh-rick
@@ -21,13 +21,7 @@ compatibility:
   dsh: ">=0.0.1-rc.1 <0.1.0 || >=0.1.0-rc.1 <0.2.0-0"
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/xxxrickymorty-dev/dsh-rick/0d17edfc9545cb456c9bde912e9b4fdddeabc4b3/docs/preview.png
-  - https://raw.githubusercontent.com/xxxrickymorty-dev/dsh-rick/0d17edfc9545cb456c9bde912e9b4fdddeabc4b3/docs/screenshots/settings.png
-  - https://raw.githubusercontent.com/xxxrickymorty-dev/dsh-rick/0d17edfc9545cb456c9bde912e9b4fdddeabc4b3/docs/screenshots/home.png
-  - https://raw.githubusercontent.com/xxxrickymorty-dev/dsh-rick/0d17edfc9545cb456c9bde912e9b4fdddeabc4b3/docs/screenshots/catchphrases.png
-  - https://raw.githubusercontent.com/xxxrickymorty-dev/dsh-rick/0d17edfc9545cb456c9bde912e9b4fdddeabc4b3/docs/screenshots/portal-wave.png
-  - https://raw.githubusercontent.com/xxxrickymorty-dev/dsh-rick/0d17edfc9545cb456c9bde912e9b4fdddeabc4b3/docs/screenshots/pickle.png
+screenshots: []
 review:
   compatibility: verified
   preview: verified
@@ -47,6 +41,7 @@ license:
 featuredRank: 196
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:32.876Z
-metadataUpdatedAt: 2026-08-19T04:41:28.988Z
+metadataUpdatedAt: 2026-08-18T15:46:32.876Z
 starsUpdatedAt: 2026-08-18T15:46:32.876Z
-updatedAt: 2026-08-19T04:41:28.988Z
+updatedAt: 2026-08-18T15:46:32.876Z
+marketScreenshots: []

--- a/registry/skins/yhPrime__dsh-theme-picker.yml
+++ b/registry/skins/yhPrime__dsh-theme-picker.yml
@@ -21,8 +21,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/3177474137d99d65242a1718a28c175f6b3461b8/yhPrime/dsh-theme-picker
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -47,3 +46,4 @@ releaseUpdatedAt: 2026-08-18T15:43:47.882Z
 metadataUpdatedAt: 2026-08-18T15:43:47.882Z
 starsUpdatedAt: 2026-08-18T15:43:47.882Z
 updatedAt: 2026-08-18T15:43:47.882Z
+marketScreenshots: []

--- a/registry/skins/ymh0000123__dsh-theme-endfield.yml
+++ b/registry/skins/ymh0000123__dsh-theme-endfield.yml
@@ -24,8 +24,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/48ad12921bd6d36286d67fa483472eb32d90b6ee/ymh0000123/dsh-theme-endfield
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -50,3 +49,4 @@ releaseUpdatedAt: 2026-08-18T15:42:02.669Z
 metadataUpdatedAt: 2026-08-18T15:42:02.669Z
 starsUpdatedAt: 2026-08-18T15:42:02.669Z
 updatedAt: 2026-08-18T15:42:02.669Z
+marketScreenshots: []

--- a/registry/skins/yoli-mi__dsh-client-ui-custom.yml
+++ b/registry/skins/yoli-mi__dsh-client-ui-custom.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-client-ui-custom
   en: dsh-client-ui-custom
 author: yoli-mi
-description: 中文 · English
+description: "Configurable DSH web-surface plugin: wallpaper & frosted-glass themes, accent colors, custom keyboard shortcuts, app-usage panel, history strip, message Markdown — zero shell edits."
 repo: https://github.com/yoli-mi/dsh-client-ui-custom
 package: "@ha-na-bi/dsh-client-ui-custom"
 rowId: ui-custom
@@ -51,6 +51,6 @@ license:
 featuredRank: 70
 starsSnapshot: 6
 releaseUpdatedAt: 2026-08-18T15:39:56.975Z
-metadataUpdatedAt: 2026-08-19T04:34:35.144Z
+metadataUpdatedAt: 2026-08-18T15:39:56.975Z
 starsUpdatedAt: 2026-08-18T15:39:56.975Z
-updatedAt: 2026-08-19T04:34:35.144Z
+updatedAt: 2026-08-18T15:39:56.975Z

--- a/registry/skins/youyli03__dsh-palenight-theme.yml
+++ b/registry/skins/youyli03__dsh-palenight-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-palenight-theme
   en: dsh-palenight-theme
 author: youyli03
-description: DeepSeek Palenight Theme(深蓝紫主题)
+description: A dynamic Cordis plugin that themes the dsh Harness Web UI — Palenight dark + warm-neutral light
 repo: https://github.com/youyli03/dsh-palenight-theme
 package: dsh-palenight-theme
 rowId: dsh-palenight-theme
@@ -46,6 +46,6 @@ license:
 featuredRank: 127
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:58:24.026Z
-metadataUpdatedAt: 2026-08-19T04:41:37.257Z
+metadataUpdatedAt: 2026-08-18T15:46:40.343Z
 starsUpdatedAt: 2026-08-16T13:58:24.026Z
-updatedAt: 2026-08-19T04:41:37.257Z
+updatedAt: 2026-08-18T15:46:40.343Z

--- a/registry/skins/yuqisun__dsh-theme-machine.yml
+++ b/registry/skins/yuqisun__dsh-theme-machine.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-theme-machine
   en: dsh-theme-machine
 author: yuqisun
-description: 《疑犯追踪》（Person of Interest）「机器」风格的 DeepSeek Harness（dsh）皮肤——为 Web UI 打造的 THE MACHINE 监视式 HUD 主题：深空蓝黑底色、机器青点缀、扫描线与网格氛围层，以及一个接入真实会话遥测的悬浮面板，让界面看起来像是有一台超级智能在背后驱动。
+description: A Person-of-Interest surveillance-terminal theme for deepseek-harness — the machine is watching.
 repo: https://github.com/yuqisun/dsh-theme-machine
 package: dsh-theme-machine
 rowId: theme-machine
@@ -47,6 +47,6 @@ license:
 featuredRank: 128
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:41.776Z
-metadataUpdatedAt: 2026-08-19T04:41:38.968Z
+metadataUpdatedAt: 2026-08-18T15:46:41.776Z
 starsUpdatedAt: 2026-08-16T13:58:28.052Z
-updatedAt: 2026-08-19T04:41:38.968Z
+updatedAt: 2026-08-18T15:46:41.776Z

--- a/registry/skins/yzke__dsh-icon-theme.yml
+++ b/registry/skins/yzke__dsh-icon-theme.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-icon-theme
   en: dsh-icon-theme
 author: yzke
-description: English | 简体中文
+description: Auto-detected, user-customizable icons for DeepSeek Harness settings and sidebar
 repo: https://github.com/yzke/dsh-icon-theme
 package: dsh-icon-theme
 rowId: dsh-icon-theme
@@ -14,17 +14,17 @@ modes:
   - light
   - dark
 install:
-  target: github:yzke/dsh-icon-theme#f0b13dbf411df0ecedf83553c5b8a51b07c694a5
-  version: 0.2.0
-  commit: f0b13dbf411df0ecedf83553c5b8a51b07c694a5
-  allowBuild: dsh-icon-theme@https://codeload.github.com/yzke/dsh-icon-theme/tar.gz/f0b13dbf411df0ecedf83553c5b8a51b07c694a5
+  target: github:yzke/dsh-icon-theme#2e341d850745ba29ae688de0eb882ecbabd17888
+  version: 0.1.1
+  commit: 2e341d850745ba29ae688de0eb882ecbabd17888
+  allowBuild: dsh-icon-theme@https://codeload.github.com/yzke/dsh-icon-theme/tar.gz/2e341d850745ba29ae688de0eb882ecbabd17888
 compatibility:
   dsh: ">=0.1.0-rc.6"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/yzke/dsh-icon-theme/f0b13dbf411df0ecedf83553c5b8a51b07c694a5/docs/images/settings-overview.png
-  - https://raw.githubusercontent.com/yzke/dsh-icon-theme/f0b13dbf411df0ecedf83553c5b8a51b07c694a5/docs/images/icon-picker.png
+  - https://raw.githubusercontent.com/yzke/dsh-icon-theme/2e341d850745ba29ae688de0eb882ecbabd17888/docs/images/settings-overview.png
+  - https://raw.githubusercontent.com/yzke/dsh-icon-theme/2e341d850745ba29ae688de0eb882ecbabd17888/docs/images/icon-picker.png
 review:
   compatibility: verified
   preview: verified
@@ -43,8 +43,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 198
-starsSnapshot: 1
-releaseUpdatedAt: 2026-08-19T04:41:40.733Z
-metadataUpdatedAt: 2026-08-19T04:41:40.733Z
-starsUpdatedAt: 2026-08-19T04:41:40.733Z
-updatedAt: 2026-08-19T04:41:40.733Z
+starsSnapshot: 0
+releaseUpdatedAt: 2026-08-18T15:46:43.240Z
+metadataUpdatedAt: 2026-08-18T15:46:43.240Z
+starsUpdatedAt: 2026-08-18T15:46:43.240Z
+updatedAt: 2026-08-18T15:46:43.240Z

--- a/registry/skins/zealot00__dsh-pet.yml
+++ b/registry/skins/zealot00__dsh-pet.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-pet
   en: dsh-pet
 author: zealot00
-description: dsh-pet — 桌面宠物插件（宠物 + 实用工具）
+description: "Desktop pet for DeepSeek Harness Web UI: sprite animation, agent state linkage, drag, alarm & pomodoro widgets, skin separation"
 repo: https://github.com/zealot00/dsh-pet
 package: "@dsh-local/dsh-pet"
 rowId: dsh-pet
@@ -45,6 +45,6 @@ license:
 featuredRank: 73
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16T13:51:35.527Z
-metadataUpdatedAt: 2026-08-19T04:35:44.364Z
+metadataUpdatedAt: 2026-08-18T15:41:05.271Z
 starsUpdatedAt: 2026-08-18T15:41:05.271Z
-updatedAt: 2026-08-19T04:35:44.364Z
+updatedAt: 2026-08-18T15:41:05.271Z

--- a/registry/skins/zenghuizhu69-hub__dsh-skin-blue-whale.yml
+++ b/registry/skins/zenghuizhu69-hub__dsh-skin-blue-whale.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-skin-blue-whale
   en: dsh-skin-blue-whale
 author: zenghuizhu69-hub
-description: 为 dsh Web UI 打造的「蓝鲸跃海」皮肤插件 —— 极简、高级，像桌面壁纸一样安静地铺在界面后面。
+description: "dsh Web UI skin: DeepSeek blue-whale theme with official gradient and leaping whale art (dsh plugin)"
 repo: https://github.com/zenghuizhu69-hub/dsh-skin-blue-whale
 package: dsh-skin-blue-whale
 rowId: blue-whale-skin
@@ -47,6 +47,6 @@ license:
 featuredRank: 56
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16T13:49:28.860Z
-metadataUpdatedAt: 2026-08-19T04:35:46.115Z
+metadataUpdatedAt: 2026-08-18T15:41:07.001Z
 starsUpdatedAt: 2026-08-16T13:49:28.860Z
-updatedAt: 2026-08-19T04:35:46.115Z
+updatedAt: 2026-08-18T15:41:07.001Z

--- a/registry/skins/zhangyuzhangyu233__dsh-angelsanddemon-fatesumphony-skin.yml
+++ b/registry/skins/zhangyuzhangyu233__dsh-angelsanddemon-fatesumphony-skin.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-angelsanddemon-fatesumphony-skin
   en: dsh-angelsanddemon-fatesumphony-skin
 author: zhangyuzhangyu233
-description: 《弹丸论破：天魔命曲》主题DSH皮肤插件
+description: dsh-angelsanddemon-fatesumphony-skin
 repo: https://github.com/zhangyuzhangyu233/dsh-angelsanddemon-fatesumphony-skin
 package: dsh-angelsanddemon-fatesumphony-skin
 rowId: dsh-angelsanddemon-fatesumphony-skin
@@ -25,8 +25,7 @@ compatibility:
   dsh: unverified
   platform:
     - web
-screenshots:
-  - https://opengraph.githubassets.com/66ee1028f5247483a2e2579260e9251fe9477ef0/zhangyuzhangyu233/dsh-angelsanddemon-fatesumphony-skin
+screenshots: []
 review:
   compatibility: unverified
   preview: repository-card
@@ -49,6 +48,7 @@ license:
 featuredRank: 199
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:46.296Z
-metadataUpdatedAt: 2026-08-19T04:41:46.788Z
+metadataUpdatedAt: 2026-08-18T15:46:46.296Z
 starsUpdatedAt: 2026-08-18T15:46:46.296Z
-updatedAt: 2026-08-19T04:41:46.788Z
+updatedAt: 2026-08-18T15:46:46.296Z
+marketScreenshots: []

--- a/registry/skins/zhijun-dai__Catppuccin-dsh-theme.yml
+++ b/registry/skins/zhijun-dai__Catppuccin-dsh-theme.yml
@@ -27,8 +27,6 @@ compatibility:
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png
-  - https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png
   - https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/preview.webp
   - https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/latte.webp
   - https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/frappe.webp
@@ -56,3 +54,4 @@ releaseUpdatedAt: 2026-08-18T15:39:27.744Z
 metadataUpdatedAt: 2026-08-18T15:39:27.744Z
 starsUpdatedAt: 2026-08-18T15:39:27.744Z
 updatedAt: 2026-08-18T15:39:27.744Z
+marketScreenshots: []

--- a/registry/skins/zhijun-dai__Solarized-dsh-theme.yml
+++ b/registry/skins/zhijun-dai__Solarized-dsh-theme.yml
@@ -23,13 +23,7 @@ compatibility:
   dsh: ^0.1.0-rc.6
   platform:
     - web
-screenshots:
-  - https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png
-  - https://raw.githubusercontent.com/zhijun-dai/Solarized-dsh-theme/6b0614e53a4314c1705967b7e3c437b64dee64f2/assets/preview.webp
-  - https://raw.githubusercontent.com/zhijun-dai/Solarized-dsh-theme/6b0614e53a4314c1705967b7e3c437b64dee64f2/assets/solarized-dark.webp
-  - https://raw.githubusercontent.com/zhijun-dai/Solarized-dsh-theme/6b0614e53a4314c1705967b7e3c437b64dee64f2/assets/solarized-light.webp
-  - https://raw.githubusercontent.com/zhijun-dai/Solarized-dsh-theme/6b0614e53a4314c1705967b7e3c437b64dee64f2/assets/selenized-dark.webp
-  - https://raw.githubusercontent.com/zhijun-dai/Solarized-dsh-theme/6b0614e53a4314c1705967b7e3c437b64dee64f2/assets/selenized-light.webp
+screenshots: []
 review:
   compatibility: verified
   preview: verified
@@ -52,3 +46,4 @@ releaseUpdatedAt: 2026-08-16T12:32:51.434Z
 metadataUpdatedAt: 2026-08-18T15:41:08.372Z
 starsUpdatedAt: 2026-08-18T15:41:08.372Z
 updatedAt: 2026-08-18T15:41:08.372Z
+marketScreenshots: []

--- a/registry/skins/zhxqc__dsh-oh-my-theme.yml
+++ b/registry/skins/zhxqc__dsh-oh-my-theme.yml
@@ -27,7 +27,6 @@ screenshots:
   - https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/slider-icon.png
   - https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/file-sys.png
   - https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/md-preview.png
-  - https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/git-changes.png
 review:
   compatibility: verified
   preview: verified
@@ -45,8 +44,9 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 10
-starsSnapshot: 6
+starsSnapshot: 4
 releaseUpdatedAt: 2026-08-18T15:40:25.196Z
 metadataUpdatedAt: 2026-08-18T15:40:25.196Z
-starsUpdatedAt: 2026-08-19T04:34:53.898Z
-updatedAt: 2026-08-19T04:34:53.898Z
+starsUpdatedAt: 2026-08-18T15:40:25.196Z
+updatedAt: 2026-08-18T15:40:25.196Z
+marketScreenshots: []

--- a/registry/skins/zsyayo112__dsh-rick-and-morty.yml
+++ b/registry/skins/zsyayo112__dsh-rick-and-morty.yml
@@ -3,7 +3,7 @@ name:
   zh: dsh-rick-and-morty
   en: dsh-rick-and-morty
 author: zsyayo112
-description: English | 中文
+description: Rick and Morty theme + desktop pet for the dsh web GUI — three skins, six companions, agent-driven moods
 repo: https://github.com/zsyayo112/dsh-rick-and-morty
 package: "@zsy1126/dsh-rick-and-morty"
 rowId: rick-and-morty
@@ -46,6 +46,6 @@ license:
 featuredRank: 166
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:43:58.602Z
-metadataUpdatedAt: 2026-08-19T04:38:48.521Z
+metadataUpdatedAt: 2026-08-18T15:43:58.602Z
 starsUpdatedAt: 2026-08-18T15:43:58.602Z
-updatedAt: 2026-08-19T04:38:48.521Z
+updatedAt: 2026-08-18T15:43:58.602Z


### PR DESCRIPTION
Clean OG card fallbacks, pure-color placeholders, 404 links, and third-party org images from screenshot lists.