### PR TITLE
feat(registry): add dsh-skin-family

### DIFF
--- a/registry/skins/smdk000__dsh-skin-family.yml
+++ b/registry/skins/smdk000__dsh-skin-family.yml
@@ -1,0 +1,40 @@
+id: dsh-skin-family
+name:
+  zh: DSH 皮肤全家桶
+  en: DSH Skin Family
+author: smdk000
+description: 8 个皮肤家族 × 15 套明暗主题 + 设置页皮肤中心;官方 --dsw-* token 机制,一键切换、零源码改动,全部通过 WCAG AA 对比度审计。A family of 8 skins × 15 light/dark themes with a built-in skin-center switcher.
+repo: https://github.com/smdk000/dsh-skin-family
+package: dsh-skin-family
+rowId: skin-family
+category: theme
+tags:
+  - token-theme
+  - light-dark
+  - multi-skin
+modes:
+  - light
+  - dark
+install:
+  target: github:smdk000/dsh-skin-family#4e90a84f140eff12aa38e7ff4a9c8f7b69771cab
+  version: 0.1.0
+  commit: 4e90a84f140eff12aa38e7ff4a9c8f7b69771cab
+compatibility:
+  dsh: 0.1.0-rc.6
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/preview-all.png
+  - https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/glass-dark.png
+  - https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/claude-dark.png
+  - https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/matrix-dark.png
+  - https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/sakura-light.png
+license:
+  code: MIT
+  commercialUse: true
+featuredRank: 999
+starsSnapshot: 0
+releaseUpdatedAt: 2026-08-19T14:25:51.000Z
+metadataUpdatedAt: 2026-08-19T14:25:51.000Z
+starsUpdatedAt: 2026-08-19T14:25:51.000Z
+updatedAt: 2026-08-19T14:25:51.000Z


### PR DESCRIPTION
## 收录皮肤:DSH 皮肤全家桶 (dsh-skin-family)

- **仓库**: https://github.com/smdk000/dsh-skin-family
- **包**: dsh-skin-family (v0.1.0)
- **安装目标**: `github:smdk000/dsh-skin-family#4e90a84f140eff12aa38e7ff4a9c8f7b69771cab`
- **许可证**: MIT(允许商用)
- **兼容性**: DSH Web 0.1.0-rc.6(web profile)
- **预览来源**: 官方 rc.6 Web UI 真机截图(CDP 无头浏览器 + 计算样式校验),见 docs/preview-all.png 与 docs/{glass,claude,matrix,sakura}-*.png
- **自动检查**:
  - registry/skin.schema.json 校验:required 字段齐全、类型无误
  - 安装命令 `dsh plugin --profile web add github:smdk000/dsh-skin-family` 可安装(官方 bundle 结构,lib/client.js 通过 ModuleLoader.load 加载,已在真实页面验证无运行错误)
  - 主题:8 家族 × 15 套明暗,全部通过 WCAG AA 对比度审计
- **风险**: 与其它皮肤插件同时启用时 token 覆盖可能互相影响,建议同一时刻只启用一个(README 已注明)