### PR TITLE
chore(skins): update automated registry

### DIFF
--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-20T09:47:55.948Z",
+  "generatedAt": "2026-08-20T10:03:12.747Z",
   "skins": [
     {
       "id": "d-dev0101.open-sea-skin",
@@ -37,14 +37,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/3d9689f0d936.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/ab2de3fe067a.gif",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/0ca6e3276866.gif",
         "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/marketplace/open-sea-harness-cover.png",
         "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-dark-overview-40.gif",
         "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-light-overview-40.gif",
         "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-wave-control-40.gif",
-        "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-daylight-sunset-40.gif"
+        "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/screenshots/harness-daylight-sunset-40.gif",
+        "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/marketplace/open-sea-harness-cover.png",
+        "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/screenshots/harness-dark-overview-40.gif",
+        "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/5bc053cb1ff2168695d4d0be710c68f8dd3ff0e2/docs/screenshots/harness-light-overview-40.gif"
       ],
       "review": {
         "compatibility": "verified",
@@ -70,15 +70,9 @@
       "featuredRank": 0,
       "starsSnapshot": 182,
       "releaseUpdatedAt": "2026-08-20T05:05:41.832Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:42.082Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:26.252Z",
       "starsUpdatedAt": "2026-08-20T05:05:41.832Z",
-      "updatedAt": "2026-08-20T06:32:42.082Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/3d9689f0d936.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/ab2de3fe067a.gif",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/0ca6e3276866.gif"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/d-dev0101/open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/docs/marketplace/open-sea-harness-cover.png"
+      "updatedAt": "2026-08-20T09:55:26.252Z"
     },
     {
       "id": "king-of-soy-sauce.liang-intensity",
@@ -113,8 +107,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/1e9bccbd1473.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/8900c286f1ad.gif",
         "https://raw.githubusercontent.com/kingOfSoySauce/dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/docs/preview.png",
         "https://raw.githubusercontent.com/kingOfSoySauce/dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/docs/demo.gif"
       ],
@@ -142,14 +134,9 @@
       "featuredRank": 1,
       "starsSnapshot": 117,
       "releaseUpdatedAt": "2026-08-18T15:38:29.706Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:46.992Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:29.971Z",
       "starsUpdatedAt": "2026-08-20T06:24:41.264Z",
-      "updatedAt": "2026-08-20T06:32:46.992Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/1e9bccbd1473.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/8900c286f1ad.gif"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/kingOfSoySauce/dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/docs/preview.png"
+      "updatedAt": "2026-08-20T09:55:29.971Z"
     },
     {
       "id": "small-tailqwq.maid-atelier",
@@ -177,9 +164,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:Small-tailqwq/dsh-deep-whale#d0419da95e51b6300de6b1c8205ee40f7644ca23&path:maid-atelier",
+        "target": "github:Small-tailqwq/dsh-deep-whale#0a3d03251d1e88a08de79e27fb884ed9200913ad&path:maid-atelier",
         "version": "0.0.1",
-        "commit": "d0419da95e51b6300de6b1c8205ee40f7644ca23"
+        "commit": "0a3d03251d1e88a08de79e27fb884ed9200913ad"
       },
       "compatibility": {
         "dsh": "0.1.0-rc.6",
@@ -188,8 +175,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Small-tailqwq__dsh-deep-whale/d0419da95e51b6300de6b1c8205ee40f7644ca23/23a6539529d1.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Small-tailqwq__dsh-deep-whale/d0419da95e51b6300de6b1c8205ee40f7644ca23/d65aadf3ef65.webp",
         "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/873f5c6d7f52aa4e4283a5ffd5598229595184da/maid-atelier/preview/light.webp",
         "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/873f5c6d7f52aa4e4283a5ffd5598229595184da/maid-atelier/preview/dark.webp"
       ],
@@ -218,16 +203,11 @@
         "notice": "仅限非商业使用；详情页必须保留原仓库 NOTICE 署名链。"
       },
       "featuredRank": 2,
-      "starsSnapshot": 1476,
-      "releaseUpdatedAt": "2026-08-20T05:05:37.073Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:34.160Z",
-      "starsUpdatedAt": "2026-08-20T06:24:30.665Z",
-      "updatedAt": "2026-08-20T06:32:34.160Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Small-tailqwq__dsh-deep-whale/d0419da95e51b6300de6b1c8205ee40f7644ca23/23a6539529d1.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Small-tailqwq__dsh-deep-whale/d0419da95e51b6300de6b1c8205ee40f7644ca23/d65aadf3ef65.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/873f5c6d7f52aa4e4283a5ffd5598229595184da/maid-atelier/preview/light.webp"
+      "starsSnapshot": 1488,
+      "releaseUpdatedAt": "2026-08-20T09:55:20.364Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:20.364Z",
+      "starsUpdatedAt": "2026-08-20T09:55:20.364Z",
+      "updatedAt": "2026-08-20T09:55:20.364Z"
     },
     {
       "id": "king-of-soy-sauce.musk-intensity",
@@ -264,9 +244,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/2dea7fdfb3b4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/20808e0f2e29.gif",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/1e9bccbd1473.png",
         "https://raw.githubusercontent.com/kingOfSoySauce/dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/assets/readme-preview.png",
         "https://raw.githubusercontent.com/kingOfSoySauce/dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/docs/musk-skin-demo.gif",
         "https://raw.githubusercontent.com/kingOfSoySauce/dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/docs/preview.png"
@@ -295,15 +272,9 @@
       "featuredRank": 2,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:42:53.218Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:47.595Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:36.213Z",
       "starsUpdatedAt": "2026-08-18T09:15:01.000Z",
-      "updatedAt": "2026-08-20T06:32:47.595Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/2dea7fdfb3b4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/20808e0f2e29.gif",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/1e9bccbd1473.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/kingOfSoySauce/dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/assets/readme-preview.png"
+      "updatedAt": "2026-08-20T09:58:36.213Z"
     },
     {
       "id": "small-tailqwq.orca-link",
@@ -330,9 +301,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:Small-tailqwq/dsh-deep-whale#3d904c8e04bbe0eafe148e74341d7c81dd94572e&path:orca-link",
+        "target": "github:Small-tailqwq/dsh-deep-whale#0a3d03251d1e88a08de79e27fb884ed9200913ad&path:orca-link",
         "version": "0.0.1",
-        "commit": "3d904c8e04bbe0eafe148e74341d7c81dd94572e"
+        "commit": "0a3d03251d1e88a08de79e27fb884ed9200913ad"
       },
       "compatibility": {
         "dsh": "unverified",
@@ -341,13 +312,15 @@
         ]
       },
       "screenshots": [
+        "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/0a3d03251d1e88a08de79e27fb884ed9200913ad/orca-link/preview/light.png",
+        "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/0a3d03251d1e88a08de79e27fb884ed9200913ad/orca-link/preview/dark.png",
         "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/3d904c8e04bbe0eafe148e74341d7c81dd94572e/orca-link/preview/light.png",
         "https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/3d904c8e04bbe0eafe148e74341d7c81dd94572e/orca-link/preview/dark.png"
       ],
       "review": {
         "compatibility": "unverified",
         "preview": "verified",
-        "installation": "manual-only"
+        "installation": "verified"
       },
       "health": {
         "status": "improvements",
@@ -359,7 +332,7 @@
           "topic": "pass"
         },
         "suggestions": [
-          "建议在 orca-link/README.md 中嵌入至少一张固定版本的 DSH Web 实机运行截图，方便用户直接确认皮肤效果。",
+          "建议在 README 中加入至少一张仓库内的真实界面截图，并让图片路径随仓库一起版本化，方便用户预览和市场稳定展示。",
           "建议在 README 或 package.json 中明确声明支持的 DSH Web 版本范围（例如 0.1.0-rc.6 或兼容区间），方便用户在安装前确认环境。"
         ]
       },
@@ -369,11 +342,11 @@
         "notice": "仅限非商业使用；详情页必须保留原仓库 NOTICE 署名链。"
       },
       "featuredRank": 3,
-      "starsSnapshot": 1448,
-      "releaseUpdatedAt": "2026-08-19T13:39:10Z",
-      "metadataUpdatedAt": "2026-08-19T15:02:45Z",
-      "starsUpdatedAt": "2026-08-19T15:02:45Z",
-      "updatedAt": "2026-08-19T15:02:45Z"
+      "starsSnapshot": 1488,
+      "releaseUpdatedAt": "2026-08-20T09:55:18.878Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:18.878Z",
+      "starsUpdatedAt": "2026-08-20T09:55:18.878Z",
+      "updatedAt": "2026-08-20T09:55:18.878Z"
     },
     {
       "id": "zhijun-dai.catppuccin",
@@ -411,9 +384,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/5dbe9a6c0862.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/2ca5e4154728.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/db159c7e1bdc.webp",
         "https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/preview.webp",
         "https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/latte.webp",
         "https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/frappe.webp",
@@ -443,15 +413,9 @@
       "featuredRank": 3,
       "starsSnapshot": 9,
       "releaseUpdatedAt": "2026-08-18 15:39:27.744000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:33:01.936Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:10.918Z",
       "starsUpdatedAt": "2026-08-18 15:39:27.744000+00:00",
-      "updatedAt": "2026-08-20T06:33:01.936Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/5dbe9a6c0862.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/2ca5e4154728.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/db159c7e1bdc.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/zhijun-dai/Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/assets/preview.webp"
+      "updatedAt": "2026-08-20T09:56:10.918Z"
     },
     {
       "id": "revolutionla.dsh-dream-skin",
@@ -487,8 +451,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RevolutionLA__dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/b3726f0b5e63.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RevolutionLA__dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/e44e667f05fd.png",
         "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/docs/screenshots/preview.png",
         "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/docs/screenshots/settings.png",
         "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/cb44e620126126061e8a0237280b4424464ecba7/docs/screenshots/preview.png",
@@ -515,16 +477,11 @@
         "commercialUse": true
       },
       "featuredRank": 4,
-      "starsSnapshot": 65,
+      "starsSnapshot": 67,
       "releaseUpdatedAt": "2026-08-20T05:05:50.110Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:33.761Z",
-      "starsUpdatedAt": "2026-08-20T05:05:50.110Z",
-      "updatedAt": "2026-08-20T06:32:33.761Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RevolutionLA__dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/b3726f0b5e63.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RevolutionLA__dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/e44e667f05fd.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/RevolutionLA/dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/docs/screenshots/preview.png"
+      "metadataUpdatedAt": "2026-08-20T09:55:34.388Z",
+      "starsUpdatedAt": "2026-08-20T09:55:34.388Z",
+      "updatedAt": "2026-08-20T09:55:34.388Z"
     },
     {
       "id": "nonamelego.dsh-catppuccin",
@@ -562,9 +519,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/134c7ddc5ba9.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/17ee53ec01d5.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/8d642012c832.png",
         "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/latte.png",
         "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/frappe.png",
         "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/macchiato.png",
@@ -595,15 +549,9 @@
       "featuredRank": 5,
       "starsSnapshot": 14,
       "releaseUpdatedAt": "2026-08-18 15:39:36.526000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:32:31.533Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:59.481Z",
       "starsUpdatedAt": "2026-08-20T05:06:13.084Z",
-      "updatedAt": "2026-08-20T06:32:31.533Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/134c7ddc5ba9.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/17ee53ec01d5.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/8d642012c832.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/NoNameLeGo/dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/assets/previews/latte.png"
+      "updatedAt": "2026-08-20T09:55:59.481Z"
     },
     {
       "id": "starslittle.dsh-blue-whale",
@@ -638,8 +586,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/starslittle__dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/78026f449395.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/starslittle__dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/5c2dd96207af.png",
         "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/docs/compare-home.png",
         "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/docs/compare-brand.png"
       ],
@@ -666,14 +612,9 @@
       "featuredRank": 6,
       "starsSnapshot": 6,
       "releaseUpdatedAt": "2026-08-18T15:39:51.782Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:53.923Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:27.639Z",
       "starsUpdatedAt": "2026-08-16T12:31:55.720Z",
-      "updatedAt": "2026-08-20T06:32:53.923Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/starslittle__dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/78026f449395.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/starslittle__dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/5c2dd96207af.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/starslittle/dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/docs/compare-home.png"
+      "updatedAt": "2026-08-20T09:56:27.639Z"
     },
     {
       "id": "caoyiwei850.dsh-client-ui-skins",
@@ -707,9 +648,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/d14628fdfa63.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/129d4d9a631e.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/f16e9b920163.jpg",
         "https://raw.githubusercontent.com/caoyiwei850/dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/assets/screenshots/mint-forest-dsh.jpg",
         "https://raw.githubusercontent.com/caoyiwei850/dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/assets/screenshots/ocean-guardian-dsh.jpg",
         "https://raw.githubusercontent.com/caoyiwei850/dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/assets/screenshots/crimson-moon-dsh.jpg"
@@ -739,15 +677,9 @@
       "featuredRank": 9,
       "starsSnapshot": 5,
       "releaseUpdatedAt": "2026-08-18T15:40:09.733Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:39.983Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:31.094Z",
       "starsUpdatedAt": "2026-08-18T15:40:09.733Z",
-      "updatedAt": "2026-08-20T06:32:39.983Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/d14628fdfa63.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/129d4d9a631e.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/f16e9b920163.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/caoyiwei850/dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/assets/screenshots/mint-forest-dsh.jpg"
+      "updatedAt": "2026-08-20T09:56:31.094Z"
     },
     {
       "id": "zhxqc.dsh-oh-my-theme",
@@ -780,9 +712,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/3c7e8dd21f9b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/0c248b74c981.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/ce9449df5314.png",
         "https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/setting.png",
         "https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/at.png",
         "https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/slider-icon.png",
@@ -812,15 +741,9 @@
       "featuredRank": 10,
       "starsSnapshot": 6,
       "releaseUpdatedAt": "2026-08-18 15:40:25.196000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:33:02.231Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:48.136Z",
       "starsUpdatedAt": "2026-08-20T05:06:53.867Z",
-      "updatedAt": "2026-08-20T06:33:02.231Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/3c7e8dd21f9b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/0c248b74c981.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/ce9449df5314.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/zhxqc/dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/docs/assets/setting.png"
+      "updatedAt": "2026-08-20T09:56:48.136Z"
     },
     {
       "id": "lhy723.dsh-neu-theme",
@@ -856,9 +779,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/554f879a86d7.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/e9ae543dbabe.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/d45f12956808.webp",
         "https://raw.githubusercontent.com/Lhy723/dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/.github/asset/dsh-neu-theme-hero.png",
         "https://raw.githubusercontent.com/Lhy723/dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/.github/asset/light.webp",
         "https://raw.githubusercontent.com/Lhy723/dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/.github/asset/dark.webp"
@@ -888,15 +808,9 @@
       "featuredRank": 11,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-18T15:40:45.859Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:27.417Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:12.547Z",
       "starsUpdatedAt": "2026-08-18T15:40:45.859Z",
-      "updatedAt": "2026-08-20T06:32:27.417Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/554f879a86d7.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/e9ae543dbabe.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/d45f12956808.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Lhy723/dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/.github/asset/dsh-neu-theme-hero.png"
+      "updatedAt": "2026-08-20T09:57:12.547Z"
     },
     {
       "id": "zhijun-dai.solarized-dsh-theme",
@@ -956,9 +870,9 @@
       "featuredRank": 12,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-16 12:32:51.434000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:26:28.823Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:24.236Z",
       "starsUpdatedAt": "2026-08-18 15:41:08.372000+00:00",
-      "updatedAt": "2026-08-20T06:26:28.823Z"
+      "updatedAt": "2026-08-20T09:57:24.236Z"
     },
     {
       "id": "kinmat-a.dsh-theme-switch",
@@ -1060,9 +974,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/294784d41473.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/c1e6cee62cac.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/53fb03f1212e.webp",
         "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/docs/screenshot.png",
         "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/assets/runtime/retro-buddy-stage.webp",
         "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/assets/runtime/blue-glass-chrome.webp",
@@ -1091,15 +1002,9 @@
       "featuredRank": 14,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-16 12:33:52.774000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:32:27.007Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:11.479Z",
       "starsUpdatedAt": "2026-08-18 15:40:44.117000+00:00",
-      "updatedAt": "2026-08-20T06:32:27.007Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/294784d41473.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/c1e6cee62cac.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/53fb03f1212e.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/LeemanCheung/dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/docs/screenshot.png"
+      "updatedAt": "2026-08-20T09:57:11.479Z"
     },
     {
       "id": "yushi-xxh.dsh-homepage-skin",
@@ -1136,8 +1041,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yushi-xxh__dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/b35f325fdeab.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yushi-xxh__dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/b134c28d4b4f.png",
         "https://raw.githubusercontent.com/yushi-xxh/dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/docs/compare-dark.png",
         "https://raw.githubusercontent.com/yushi-xxh/dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/docs/compare-light.png"
       ],
@@ -1164,14 +1067,9 @@
       "featuredRank": 15,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T12:34:09.222Z",
-      "metadataUpdatedAt": "2026-08-20T06:33:00.598Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:25.771Z",
       "starsUpdatedAt": "2026-08-18T15:43:54.246Z",
-      "updatedAt": "2026-08-20T06:33:00.598Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yushi-xxh__dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/b35f325fdeab.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yushi-xxh__dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/b134c28d4b4f.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/yushi-xxh/dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/docs/compare-dark.png"
+      "updatedAt": "2026-08-20T09:59:25.771Z"
     },
     {
       "id": "docjlm.pramanix-eyjafjalla",
@@ -1208,7 +1106,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/DocJlm__dsh-arknights/87116ed1536c61dbb287addd9e4830cf3e8e0f36/28f69a05a44e.webp",
         "https://raw.githubusercontent.com/DocJlm/dsh-arknights/87116ed1536c61dbb287addd9e4830cf3e8e0f36/skins/pramanix-eyjafjalla/preview/cover.webp",
         "https://raw.githubusercontent.com/DocJlm/dsh-arknights/6419ea4d249945daa4bc05112b32ee868f5d2d6c/skins/pramanix-eyjafjalla/preview/cover.webp"
       ],
@@ -1237,13 +1134,9 @@
       "featuredRank": 17,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T05:07:35.441Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:23.219Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:39.074Z",
       "starsUpdatedAt": "2026-08-18T15:41:31.928Z",
-      "updatedAt": "2026-08-20T06:32:23.219Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/DocJlm__dsh-arknights/87116ed1536c61dbb287addd9e4830cf3e8e0f36/28f69a05a44e.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/DocJlm/dsh-arknights/87116ed1536c61dbb287addd9e4830cf3e8e0f36/skins/pramanix-eyjafjalla/preview/cover.webp"
+      "updatedAt": "2026-08-20T09:57:39.074Z"
     },
     {
       "id": "kingao294.dsh-skin",
@@ -1423,9 +1316,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/e4be5edfdd62.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/2cd0157329ee.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/ddd024f450c7.jpg",
         "https://raw.githubusercontent.com/xingyingyuzhui/dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/docs/preview/ice-hero.jpg",
         "https://raw.githubusercontent.com/xingyingyuzhui/dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/docs/preview/deepwater-chat.jpg",
         "https://raw.githubusercontent.com/xingyingyuzhui/dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/docs/preview/settings.jpg",
@@ -1456,15 +1346,9 @@
       "featuredRank": 21,
       "starsSnapshot": 11,
       "releaseUpdatedAt": "2026-08-16T12:15:45.060Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:59.263Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:06.377Z",
       "starsUpdatedAt": "2026-08-18T15:39:21.792Z",
-      "updatedAt": "2026-08-20T06:32:59.263Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/e4be5edfdd62.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/2cd0157329ee.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/ddd024f450c7.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/xingyingyuzhui/dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/docs/preview/ice-hero.jpg"
+      "updatedAt": "2026-08-20T09:56:06.377Z"
     },
     {
       "id": "yunxiiqwq.maid-whale-webui",
@@ -1501,8 +1385,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yunxiiQwQ__dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/152d5cd134c3.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yunxiiQwQ__dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/aa0c5d4b1f5c.webp",
         "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/maid-whale-webui/preview/light.webp",
         "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/maid-whale-webui/preview/dark.webp"
       ],
@@ -1529,16 +1411,11 @@
         "commercialUse": true
       },
       "featuredRank": 22,
-      "starsSnapshot": 16,
+      "starsSnapshot": 18,
       "releaseUpdatedAt": "2026-08-16T12:48:35.081Z",
-      "metadataUpdatedAt": "2026-08-20T06:33:00.085Z",
-      "starsUpdatedAt": "2026-08-20T06:25:12.051Z",
-      "updatedAt": "2026-08-20T06:33:00.085Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yunxiiQwQ__dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/152d5cd134c3.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yunxiiQwQ__dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/aa0c5d4b1f5c.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/yunxiiQwQ/dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/maid-whale-webui/preview/light.webp"
+      "metadataUpdatedAt": "2026-08-20T09:56:02.381Z",
+      "starsUpdatedAt": "2026-08-20T09:56:02.381Z",
+      "updatedAt": "2026-08-20T09:56:02.381Z"
     },
     {
       "id": "pakiknowledge.dsh-client-ui-skin-claude",
@@ -1572,8 +1449,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/PAKIKNOWLEDGE__dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/2f7a34186827.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/PAKIKNOWLEDGE__dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/43ce9beb5849.png",
         "https://raw.githubusercontent.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/docs/dark.png",
         "https://raw.githubusercontent.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/docs/light.png",
         "https://raw.githubusercontent.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude/78690f8449b61c0ea00e827c7427934810b9c554/docs/dark.png",
@@ -1602,14 +1477,9 @@
       "featuredRank": 23,
       "starsSnapshot": 7,
       "releaseUpdatedAt": "2026-08-20T05:06:27.719Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:31.870Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:19.522Z",
       "starsUpdatedAt": "2026-08-18T15:39:39.240Z",
-      "updatedAt": "2026-08-20T06:32:31.870Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/PAKIKNOWLEDGE__dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/2f7a34186827.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/PAKIKNOWLEDGE__dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/43ce9beb5849.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/PAKIKNOWLEDGE/dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/docs/dark.png"
+      "updatedAt": "2026-08-20T09:56:19.522Z"
     },
     {
       "id": "aks1st.dsh-cyber-particle",
@@ -1646,8 +1516,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/582dd9739f30.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/c2182e95ae81.png",
         "https://raw.githubusercontent.com/AKS1st/dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/assets/image_light.png",
         "https://raw.githubusercontent.com/AKS1st/dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/assets/image_dark.png"
       ],
@@ -1676,14 +1544,9 @@
       "featuredRank": 25,
       "starsSnapshot": 10,
       "releaseUpdatedAt": "2026-08-18T15:39:29.241Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:20.944Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:07.415Z",
       "starsUpdatedAt": "2026-08-20T05:06:17.976Z",
-      "updatedAt": "2026-08-20T06:32:20.944Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/582dd9739f30.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/c2182e95ae81.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/AKS1st/dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/assets/image_light.png"
+      "updatedAt": "2026-08-20T09:56:07.415Z"
     },
     {
       "id": "beizi6.dsh-theme-plugin",
@@ -1784,7 +1647,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SamizuHM__dsh-client-ui-theme-xp/3cc412f4e877c127dea2e5b6e3413e5ddc95ce97/e256c4e2c123.png",
         "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/3cc412f4e877c127dea2e5b6e3413e5ddc95ce97/docs/screenshot.png"
       ],
       "review": {
@@ -1812,13 +1674,9 @@
       "featuredRank": 28,
       "starsSnapshot": 6,
       "releaseUpdatedAt": "2026-08-16T12:16:17.062Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:33.927Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:41.425Z",
       "starsUpdatedAt": "2026-08-20T05:06:47.767Z",
-      "updatedAt": "2026-08-20T06:32:33.927Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SamizuHM__dsh-client-ui-theme-xp/3cc412f4e877c127dea2e5b6e3413e5ddc95ce97/e256c4e2c123.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/SamizuHM/dsh-client-ui-theme-xp/3cc412f4e877c127dea2e5b6e3413e5ddc95ce97/docs/screenshot.png"
+      "updatedAt": "2026-08-20T09:56:41.425Z"
     },
     {
       "id": "dsh-plugins.dsh-thought-buddy",
@@ -1929,7 +1787,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/MangMax__dsh-themes/85fe103cc2792da5eec2d57b045509256a5206d1/2ccaab0f3f0f.png",
         "https://raw.githubusercontent.com/MangMax/dsh-themes/85fe103cc2792da5eec2d57b045509256a5206d1/assets/screenshot.png"
       ],
       "review": {
@@ -1958,13 +1815,9 @@
       "featuredRank": 30,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:43:10.613Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:29.920Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:48.348Z",
       "starsUpdatedAt": "2026-08-16T12:16:26.193Z",
-      "updatedAt": "2026-08-20T06:32:29.920Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/MangMax__dsh-themes/85fe103cc2792da5eec2d57b045509256a5206d1/2ccaab0f3f0f.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/MangMax/dsh-themes/85fe103cc2792da5eec2d57b045509256a5206d1/assets/screenshot.png"
+      "updatedAt": "2026-08-20T09:58:48.348Z"
     },
     {
       "id": "senrylee.dsh-frosted-window",
@@ -2001,7 +1854,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SenryLee__dsh-frosted-window/ccee61d02837d2e3e3160743c07c8627a40c3438/b6930f43faad.jpg",
         "https://raw.githubusercontent.com/SenryLee/dsh-frosted-window/ccee61d02837d2e3e3160743c07c8627a40c3438/docs/preview.jpg"
       ],
       "review": {
@@ -2029,13 +1881,9 @@
       "featuredRank": 31,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:43:32.583Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:34.049Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:05.199Z",
       "starsUpdatedAt": "2026-08-16T12:16:30.062Z",
-      "updatedAt": "2026-08-20T06:32:34.049Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SenryLee__dsh-frosted-window/ccee61d02837d2e3e3160743c07c8627a40c3438/b6930f43faad.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/SenryLee/dsh-frosted-window/ccee61d02837d2e3e3160743c07c8627a40c3438/docs/preview.jpg"
+      "updatedAt": "2026-08-20T09:59:05.199Z"
     },
     {
       "id": "aks1st.ikun-theme-skin",
@@ -2197,10 +2045,10 @@
         "dark"
       ],
       "install": {
-        "target": "github:TQSY114514/dsh-ui-appearance#0b47a643cd531ac4115867da7bee98588683f42e",
+        "target": "github:TQSY114514/dsh-ui-appearance#19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9",
         "version": "0.1.3",
-        "commit": "0b47a643cd531ac4115867da7bee98588683f42e",
-        "allowBuild": "dsh-ui-appearance@https://codeload.github.com/TQSY114514/dsh-ui-appearance/tar.gz/0b47a643cd531ac4115867da7bee98588683f42e"
+        "commit": "19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9",
+        "allowBuild": "dsh-ui-appearance@https://codeload.github.com/TQSY114514/dsh-ui-appearance/tar.gz/19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9"
       },
       "compatibility": {
         "dsh": "unverified",
@@ -2209,8 +2057,8 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/TQSY114514__dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/4acbf420f1a9.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/TQSY114514__dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/6beb1109ae17.png",
+        "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9/docs/screenshot-settings.png",
+        "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9/docs/screenshot-wallpaper.png",
         "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/docs/screenshot-settings.png",
         "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/docs/screenshot-wallpaper.png",
         "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c/docs/screenshot-settings.png",
@@ -2241,15 +2089,10 @@
       },
       "featuredRank": 36,
       "starsSnapshot": 9,
-      "releaseUpdatedAt": "2026-08-20T05:06:28.645Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:35.737Z",
+      "releaseUpdatedAt": "2026-08-20T09:56:20.540Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:20.540Z",
       "starsUpdatedAt": "2026-08-20T06:25:29.500Z",
-      "updatedAt": "2026-08-20T06:32:35.737Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/TQSY114514__dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/4acbf420f1a9.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/TQSY114514__dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/6beb1109ae17.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/docs/screenshot-settings.png"
+      "updatedAt": "2026-08-20T09:56:20.540Z"
     },
     {
       "id": "wyh66666666.dsh-transparent-ui-plugin",
@@ -2274,9 +2117,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:WYH66666666/DSH-Transparent-UI-Plugin#fa0cb1fd172a1301297727334b08d8322ee57077",
+        "target": "github:WYH66666666/DSH-Transparent-UI-Plugin#27ebacb504f43c31c29c4b700b54f902a26da978",
         "version": "1.3.0",
-        "commit": "fa0cb1fd172a1301297727334b08d8322ee57077"
+        "commit": "27ebacb504f43c31c29c4b700b54f902a26da978"
       },
       "compatibility": {
         "dsh": "^0.1.0-rc.5",
@@ -2285,9 +2128,10 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/92e236a557ce.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/0914e4e4b4ff.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/8fdc55ae4a15.png",
+        "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/1.png",
+        "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/2.png",
+        "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/3.png",
+        "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/4.png",
         "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/1.png",
         "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/2.png",
         "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/3.png",
@@ -2314,17 +2158,11 @@
         "commercialUse": true
       },
       "featuredRank": 37,
-      "starsSnapshot": 334,
-      "releaseUpdatedAt": "2026-08-18T15:38:18.212Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:36.800Z",
-      "starsUpdatedAt": "2026-08-20T05:05:40.058Z",
-      "updatedAt": "2026-08-20T06:32:36.800Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/92e236a557ce.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/0914e4e4b4ff.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/8fdc55ae4a15.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/1.png"
+      "starsSnapshot": 337,
+      "releaseUpdatedAt": "2026-08-20T09:55:23.785Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:23.785Z",
+      "starsUpdatedAt": "2026-08-20T09:55:23.785Z",
+      "updatedAt": "2026-08-20T09:55:23.785Z"
     },
     {
       "id": "dancingmemory.dskin",
@@ -2347,10 +2185,10 @@
         "dark"
       ],
       "install": {
-        "target": "github:dancingmemory/dskin#9ec8661b49bdf1a94250dcee9710cec22162a865",
-        "version": "1.0.15",
-        "commit": "9ec8661b49bdf1a94250dcee9710cec22162a865",
-        "allowBuild": "dskin@https://codeload.github.com/dancingmemory/dskin/tar.gz/9ec8661b49bdf1a94250dcee9710cec22162a865"
+        "target": "github:dancingmemory/dskin#792064e6dbb022c5f9ce3529b9cf66efba2863c1",
+        "version": "1.0.16",
+        "commit": "792064e6dbb022c5f9ce3529b9cf66efba2863c1",
+        "allowBuild": "dskin@https://codeload.github.com/dancingmemory/dskin/tar.gz/792064e6dbb022c5f9ce3529b9cf66efba2863c1"
       },
       "compatibility": {
         "dsh": "unverified",
@@ -2359,14 +2197,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/803075b9acef.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/b150c6915f94.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/c62c291ee287.png",
+        "https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/banner.jpg",
+        "https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-bigorange.png",
+        "https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-white.png",
+        "https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-black.png",
+        "https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-tuxedo.png",
         "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/banner.jpg",
         "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-bigorange.png",
-        "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-white.png",
-        "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-black.png",
-        "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-tuxedo.png"
+        "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-white.png"
       ],
       "review": {
         "compatibility": "unverified",
@@ -2392,16 +2230,10 @@
       },
       "featuredRank": 38,
       "starsSnapshot": 7,
-      "releaseUpdatedAt": "2026-08-20T05:06:24.008Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:43.021Z",
+      "releaseUpdatedAt": "2026-08-20T09:56:13.699Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:13.699Z",
       "starsUpdatedAt": "2026-08-18T15:39:30.818Z",
-      "updatedAt": "2026-08-20T06:32:43.021Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/803075b9acef.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/b150c6915f94.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/c62c291ee287.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/banner.jpg"
+      "updatedAt": "2026-08-20T09:56:13.699Z"
     },
     {
       "id": "xiake595.touhou-hakurei",
@@ -2439,14 +2271,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/19cde8d3107b.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/b728cc860011.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/8611ab5c06b3.webp",
         "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/preview/light.webp",
         "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/preview/dark.webp",
         "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/screenshots/shot-dark-1.webp",
         "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/screenshots/shot-dark-2.webp",
-        "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/screenshots/shot-light-1.webp"
+        "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/screenshots/shot-light-1.webp",
+        "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/screenshots/shot-light-2.webp"
       ],
       "review": {
         "compatibility": "unverified",
@@ -2473,15 +2303,9 @@
       "featuredRank": 39,
       "starsSnapshot": 17,
       "releaseUpdatedAt": "2026-08-16T13:47:01.836Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:58.264Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:58.320Z",
       "starsUpdatedAt": "2026-08-20T05:06:09.460Z",
-      "updatedAt": "2026-08-20T06:32:58.264Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/19cde8d3107b.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/b728cc860011.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/8611ab5c06b3.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/xiake595/touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/preview/light.webp"
+      "updatedAt": "2026-08-20T09:55:58.320Z"
     },
     {
       "id": "laplaceyoung.dsh-qq2006",
@@ -2516,8 +2340,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LaplaceYoung__dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/f185d2fa7e19.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LaplaceYoung__dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/8d4ea88b905c.webp",
         "https://raw.githubusercontent.com/LaplaceYoung/dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/assets/screenshots/qq2006-window-view.webp",
         "https://raw.githubusercontent.com/LaplaceYoung/dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/assets/screenshots/qq2006-window-chrome.webp"
       ],
@@ -2544,14 +2366,9 @@
       "featuredRank": 40,
       "starsSnapshot": 19,
       "releaseUpdatedAt": "2026-08-16 13:47:05.463000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:32:26.748Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:53.604Z",
       "starsUpdatedAt": "2026-08-20T06:25:04.252Z",
-      "updatedAt": "2026-08-20T06:32:26.748Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LaplaceYoung__dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/f185d2fa7e19.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LaplaceYoung__dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/8d4ea88b905c.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/LaplaceYoung/dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/assets/screenshots/qq2006-window-view.webp"
+      "updatedAt": "2026-08-20T09:55:53.604Z"
     },
     {
       "id": "suzike.freestyle-dsh-theme",
@@ -2586,8 +2403,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/suzike__freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/860e85d3e154.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/suzike__freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/3453249b5f1b.png",
         "https://raw.githubusercontent.com/suzike/freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/docs/images/screenshot-proposer.png",
         "https://raw.githubusercontent.com/suzike/freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/docs/images/screenshot-designer.png"
       ],
@@ -2617,14 +2432,9 @@
       "featuredRank": 41,
       "starsSnapshot": 12,
       "releaseUpdatedAt": "2026-08-16T13:47:08.953Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:54.071Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:05.313Z",
       "starsUpdatedAt": "2026-08-18T15:39:16.749Z",
-      "updatedAt": "2026-08-20T06:32:54.071Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/suzike__freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/860e85d3e154.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/suzike__freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/3453249b5f1b.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/suzike/freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/docs/images/screenshot-proposer.png"
+      "updatedAt": "2026-08-20T09:56:05.313Z"
     },
     {
       "id": "lssyd20070106.dsh-ui-preset-enhance",
@@ -2659,8 +2469,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lssyd20070106__dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/b7bc18eb093a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lssyd20070106__dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/6f50d463e0f0.png",
         "https://raw.githubusercontent.com/lssyd20070106/dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/assets/preview-home.png",
         "https://raw.githubusercontent.com/lssyd20070106/dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/assets/preview-settings.png"
       ],
@@ -2687,14 +2495,9 @@
       "featuredRank": 42,
       "starsSnapshot": 7,
       "releaseUpdatedAt": "2026-08-16T13:47:45.102Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:49.257Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:17.210Z",
       "starsUpdatedAt": "2026-08-18T15:39:35.097Z",
-      "updatedAt": "2026-08-20T06:32:49.257Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lssyd20070106__dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/b7bc18eb093a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lssyd20070106__dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/6f50d463e0f0.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/lssyd20070106/dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/assets/preview-home.png"
+      "updatedAt": "2026-08-20T09:56:17.210Z"
     },
     {
       "id": "dviridescent.dafy-whale-theme",
@@ -2799,8 +2602,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Misaki14987__dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/43afff001929.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Misaki14987__dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/618a875a5a33.png",
         "https://raw.githubusercontent.com/Misaki14987/dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/docs/screenshot-dark.png",
         "https://raw.githubusercontent.com/Misaki14987/dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/docs/screenshot-light.png"
       ],
@@ -2827,14 +2628,9 @@
       "featuredRank": 44,
       "starsSnapshot": 6,
       "releaseUpdatedAt": "2026-08-16T13:48:03.686Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:30.029Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:26.591Z",
       "starsUpdatedAt": "2026-08-18T15:39:47.552Z",
-      "updatedAt": "2026-08-20T06:32:30.029Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Misaki14987__dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/43afff001929.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Misaki14987__dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/618a875a5a33.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Misaki14987/dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/docs/screenshot-dark.png"
+      "updatedAt": "2026-08-20T09:56:26.591Z"
     },
     {
       "id": "vim0x3c.dsh-skin-appearance",
@@ -2871,14 +2667,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/15b08e2328e9.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/b8d74e78f8a7.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/538476f151b3.jpg",
         "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/deepseek-chan.jpg",
         "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/qq2008-crystal.jpg",
         "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/cloud-lab.jpg",
         "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/ink-algorithm.jpg",
-        "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/abyss-starport.jpg"
+        "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/abyss-starport.jpg",
+        "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/deepsea-whale.jpg",
+        "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/be7b05776c1dee9e3d387e122c42005edf400837/assets/screenshots/deepseek-chan.jpg",
+        "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/be7b05776c1dee9e3d387e122c42005edf400837/assets/screenshots/qq2008-crystal.jpg"
       ],
       "review": {
         "compatibility": "verified",
@@ -2905,15 +2701,9 @@
       "featuredRank": 45,
       "starsSnapshot": 5,
       "releaseUpdatedAt": "2026-08-20T06:25:54.319Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:36.482Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:47.073Z",
       "starsUpdatedAt": "2026-08-16T13:48:16.554Z",
-      "updatedAt": "2026-08-20T06:32:36.482Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/15b08e2328e9.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/b8d74e78f8a7.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/538476f151b3.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Vim0x3c/dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/assets/screenshots/deepseek-chan.jpg"
+      "updatedAt": "2026-08-20T09:56:47.073Z"
     },
     {
       "id": "drfccv.dsh-theme-neko",
@@ -2949,7 +2739,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/drfccv__dsh-theme-neko/6c7c9a58ff93cef7117cbfc3b48a295039cd7c45/603f39169545.png",
         "https://raw.githubusercontent.com/drfccv/dsh-theme-neko/6c7c9a58ff93cef7117cbfc3b48a295039cd7c45/sample/screenshot.png"
       ],
       "review": {
@@ -2978,13 +2767,9 @@
       "featuredRank": 46,
       "starsSnapshot": 4,
       "releaseUpdatedAt": "2026-08-18T15:40:11.189Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:43.197Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:55.033Z",
       "starsUpdatedAt": "2026-08-16T13:48:19.998Z",
-      "updatedAt": "2026-08-20T06:32:43.197Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/drfccv__dsh-theme-neko/6c7c9a58ff93cef7117cbfc3b48a295039cd7c45/603f39169545.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/drfccv/dsh-theme-neko/6c7c9a58ff93cef7117cbfc3b48a295039cd7c45/sample/screenshot.png"
+      "updatedAt": "2026-08-20T09:56:55.033Z"
     },
     {
       "id": "ai7603.dsh-cyberpunk-theme",
@@ -3019,8 +2804,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ai7603__dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/53a60b9880b0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ai7603__dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/b990701c911a.png",
         "https://raw.githubusercontent.com/ai7603/dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/docs/screenshots/session-dark.png",
         "https://raw.githubusercontent.com/ai7603/dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/docs/screenshots/session-light.png"
       ],
@@ -3049,14 +2832,9 @@
       "featuredRank": 47,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-16T13:48:35.219Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:39.099Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:04.724Z",
       "starsUpdatedAt": "2026-08-16T13:48:35.219Z",
-      "updatedAt": "2026-08-20T06:32:39.099Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ai7603__dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/53a60b9880b0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ai7603__dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/b990701c911a.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ai7603/dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/docs/screenshots/session-dark.png"
+      "updatedAt": "2026-08-20T09:57:04.724Z"
     },
     {
       "id": "anneheartrecord.dsh-desk-pet",
@@ -3142,9 +2920,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/75e7d091c15c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/857540e8612a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/f3f8f5da7110.png",
         "https://raw.githubusercontent.com/Estellalee/dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/screenshots/light-sunset.png",
         "https://raw.githubusercontent.com/Estellalee/dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/screenshots/light-moonrise.png",
         "https://raw.githubusercontent.com/Estellalee/dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/screenshots/dark-mode.png",
@@ -3174,15 +2949,9 @@
       "featuredRank": 49,
       "starsSnapshot": 4,
       "releaseUpdatedAt": "2026-08-16T13:48:50.122Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:24.150Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:56.192Z",
       "starsUpdatedAt": "2026-08-18T15:40:12.882Z",
-      "updatedAt": "2026-08-20T06:32:24.150Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/75e7d091c15c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/857540e8612a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/f3f8f5da7110.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Estellalee/dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/screenshots/light-sunset.png"
+      "updatedAt": "2026-08-20T09:56:56.192Z"
     },
     {
       "id": "le-soleil-se-couche.dsh-skin-claude-code",
@@ -3216,8 +2985,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/le-soleil-se-couche__dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/9a132e947166.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/le-soleil-se-couche__dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/80dec7d5302b.png",
         "https://raw.githubusercontent.com/le-soleil-se-couche/dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/docs/codex-config.png",
         "https://raw.githubusercontent.com/le-soleil-se-couche/dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/preview/light.png"
       ],
@@ -3246,14 +3013,9 @@
       "featuredRank": 50,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-18T15:40:42.529Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:47.832Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:10.248Z",
       "starsUpdatedAt": "2026-08-16T13:49:00.442Z",
-      "updatedAt": "2026-08-20T06:32:47.832Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/le-soleil-se-couche__dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/9a132e947166.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/le-soleil-se-couche__dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/80dec7d5302b.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/le-soleil-se-couche/dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/docs/codex-config.png"
+      "updatedAt": "2026-08-20T09:57:10.248Z"
     },
     {
       "id": "makuralymi.dsh-webui-glass-theme",
@@ -3289,8 +3051,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/makuralymi__dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/36757d3e0dad.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/makuralymi__dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/481e5e2eacbb.png",
         "https://raw.githubusercontent.com/makuralymi/dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/assets/sc.png",
         "https://raw.githubusercontent.com/makuralymi/dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/assets/sc2.png",
         "https://raw.githubusercontent.com/makuralymi/dsh-webUI-Glass-Theme/b76db9b1a96074a44eef0e87c2346a528065f1fe/assets/sc.png",
@@ -3319,14 +3079,9 @@
       "featuredRank": 53,
       "starsSnapshot": 4,
       "releaseUpdatedAt": "2026-08-20T05:07:01.312Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:50.545Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:59.474Z",
       "starsUpdatedAt": "2026-08-18T15:40:20.925Z",
-      "updatedAt": "2026-08-20T06:32:50.545Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/makuralymi__dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/36757d3e0dad.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/makuralymi__dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/481e5e2eacbb.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/makuralymi/dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/assets/sc.png"
+      "updatedAt": "2026-08-20T09:56:59.474Z"
     },
     {
       "id": "zenghuizhu69-hub.dsh-skin-blue-whale",
@@ -3363,8 +3118,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zenghuizhu69-hub__dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/7976b6031fb4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zenghuizhu69-hub__dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/182c7023e9ee.png",
         "https://raw.githubusercontent.com/zenghuizhu69-hub/dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/screenshots/hero.png",
         "https://raw.githubusercontent.com/zenghuizhu69-hub/dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/screenshots/work.png"
       ],
@@ -3391,14 +3144,9 @@
       "featuredRank": 56,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-16T13:49:28.860Z",
-      "metadataUpdatedAt": "2026-08-20T06:33:01.626Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:23.187Z",
       "starsUpdatedAt": "2026-08-16T13:49:28.860Z",
-      "updatedAt": "2026-08-20T06:33:01.626Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zenghuizhu69-hub__dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/7976b6031fb4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zenghuizhu69-hub__dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/182c7023e9ee.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/zenghuizhu69-hub/dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/screenshots/hero.png"
+      "updatedAt": "2026-08-20T09:57:23.187Z"
     },
     {
       "id": "anionex.dsh-eye-care",
@@ -3435,8 +3183,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Anionex__dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/ca1f4ec70142.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Anionex__dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/38732e0f0e3c.png",
         "https://raw.githubusercontent.com/Anionex/dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/assets/eye-care-light.png",
         "https://raw.githubusercontent.com/Anionex/dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/assets/eye-care-dark.png"
       ],
@@ -3463,14 +3209,9 @@
       "featuredRank": 57,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-16T13:49:43.768Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:21.275Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:30.823Z",
       "starsUpdatedAt": "2026-08-16T13:49:43.768Z",
-      "updatedAt": "2026-08-20T06:32:21.275Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Anionex__dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/ca1f4ec70142.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Anionex__dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/38732e0f0e3c.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Anionex/dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/assets/eye-care-light.png"
+      "updatedAt": "2026-08-20T09:57:30.823Z"
     },
     {
       "id": "bilbillm.deepseek-harness-angelina-themes",
@@ -3507,14 +3248,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/052fe3ce7291.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/b0162272fb17.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/e58e9a8506c5.webp",
         "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/src/assets/angelina-light-hero.webp",
         "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/src/assets/angelina-dark-hero.webp",
         "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/src/assets/angelina-light-parallax-background.webp",
         "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/src/assets/angelina-light-parallax-foreground.webp",
-        "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/docs/screenshots/glass-actions-menu.png"
+        "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/docs/screenshots/glass-actions-menu.png",
+        "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/docs/screenshots/glass-sort-menu.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -3539,15 +3278,9 @@
       "featuredRank": 58,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-18T15:40:34.001Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:39.780Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:07.073Z",
       "starsUpdatedAt": "2026-08-18T15:40:34.001Z",
-      "updatedAt": "2026-08-20T06:32:39.780Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/052fe3ce7291.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/b0162272fb17.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/e58e9a8506c5.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/bilbillm/deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/src/assets/angelina-light-hero.webp"
+      "updatedAt": "2026-08-20T09:57:07.073Z"
     },
     {
       "id": "carpon39038.dsh-image-theme",
@@ -3608,9 +3341,9 @@
       "featuredRank": 60,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-16 13:50:02.941000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:26:37.362Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:32.882Z",
       "starsUpdatedAt": "2026-08-16 13:50:02.941000+00:00",
-      "updatedAt": "2026-08-20T06:26:37.362Z"
+      "updatedAt": "2026-08-20T09:57:32.882Z"
     },
     {
       "id": "chajiuqqq.dsh-claude-theme",
@@ -3851,14 +3584,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/03514f2ef469.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/b6b4f08e77f0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/5e94bdbc56f4.png",
         "https://count.getloli.com/@liuli-theme?theme=rule34",
         "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/docs/preview-start-light.png",
         "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/docs/preview-start-dark.png",
         "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/docs/preview-color-light.png",
-        "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/docs/preview-color-dark.png"
+        "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/docs/preview-color-dark.png",
+        "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/docs/preview-session-dark.png",
+        "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/307eb04764a24ff8ba3f3bd7a2eb5e103fc772d6/docs/preview-start-light.png",
+        "https://raw.githubusercontent.com/LilycleHeart/liuli-theme/307eb04764a24ff8ba3f3bd7a2eb5e103fc772d6/docs/preview-start-dark.png"
       ],
       "review": {
         "compatibility": "unverified",
@@ -3887,15 +3620,9 @@
       "featuredRank": 64,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T05:07:44.182Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:29.265Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:45.623Z",
       "starsUpdatedAt": "2026-08-16T13:50:39.220Z",
-      "updatedAt": "2026-08-20T06:32:29.265Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/03514f2ef469.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/b6b4f08e77f0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/5e94bdbc56f4.png"
-      ],
-      "listScreenshot": "https://count.getloli.com/@liuli-theme?theme=rule34"
+      "updatedAt": "2026-08-20T09:57:45.623Z"
     },
     {
       "id": "moonshadow1976.chiral-pulse",
@@ -4052,7 +3779,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wangxilhy23__dsh-wx-skin/5351f776e73331ed70f5b656c8373c83b7a559a9/6803c02ed466.png",
         "https://raw.githubusercontent.com/wangxilhy23/dsh-wx-skin/5351f776e73331ed70f5b656c8373c83b7a559a9/assets/demo1.png",
         "https://raw.githubusercontent.com/wangxilhy23/dsh-wx-skin/1dce62c660fbc2525e1358f864dba797d2f9d5c3/assets/demo1.png"
       ],
@@ -4082,13 +3808,9 @@
       "featuredRank": 68,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T05:07:52.874Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:57.007Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:57.193Z",
       "starsUpdatedAt": "2026-08-16T13:51:09.489Z",
-      "updatedAt": "2026-08-20T06:32:57.007Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wangxilhy23__dsh-wx-skin/5351f776e73331ed70f5b656c8373c83b7a559a9/6803c02ed466.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/wangxilhy23/dsh-wx-skin/5351f776e73331ed70f5b656c8373c83b7a559a9/assets/demo1.png"
+      "updatedAt": "2026-08-20T09:57:57.193Z"
     },
     {
       "id": "wanzhiwei5.dsh-skin-amis",
@@ -4124,8 +3846,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wanzhiwei5__dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/d0e074a3f7c5.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wanzhiwei5__dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/fd43823d52be.png",
         "https://raw.githubusercontent.com/wanzhiwei5/dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/preview/light.png",
         "https://raw.githubusercontent.com/wanzhiwei5/dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/preview/dark.png"
       ],
@@ -4154,14 +3874,9 @@
       "featuredRank": 69,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-16T13:51:14.660Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:57.238Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:58.275Z",
       "starsUpdatedAt": "2026-08-16T13:51:14.660Z",
-      "updatedAt": "2026-08-20T06:32:57.238Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wanzhiwei5__dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/d0e074a3f7c5.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wanzhiwei5__dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/fd43823d52be.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/wanzhiwei5/dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/preview/light.png"
+      "updatedAt": "2026-08-20T09:57:58.275Z"
     },
     {
       "id": "yoli-mi.dsh-client-ui-custom",
@@ -4274,8 +3989,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zealot00__dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/af59e6cbfa0e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zealot00__dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/9c191f17a218.png",
         "https://raw.githubusercontent.com/zealot00/dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/docs/screenshot-states.png",
         "https://raw.githubusercontent.com/zealot00/dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/docs/screenshot-scene.png"
       ],
@@ -4304,14 +4017,9 @@
       "featuredRank": 73,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-16T13:51:35.527Z",
-      "metadataUpdatedAt": "2026-08-20T06:33:01.200Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:22.092Z",
       "starsUpdatedAt": "2026-08-18T15:41:05.271Z",
-      "updatedAt": "2026-08-20T06:33:01.200Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zealot00__dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/af59e6cbfa0e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zealot00__dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/9c191f17a218.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/zealot00/dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/docs/screenshot-states.png"
+      "updatedAt": "2026-08-20T09:57:22.092Z"
     },
     {
       "id": "0nt-one.dsh-neo-skin",
@@ -4346,9 +4054,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/6edff6216e23.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/61370c151ab7.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/8308768fc836.png",
         "https://raw.githubusercontent.com/0nt-one/dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/screenshots/app-light.png",
         "https://raw.githubusercontent.com/0nt-one/dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/screenshots/app-dark.png",
         "https://raw.githubusercontent.com/0nt-one/dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/screenshots/newspaper.png"
@@ -4378,15 +4083,9 @@
       "featuredRank": 74,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-16T13:51:42.695Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:19.550Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:25.326Z",
       "starsUpdatedAt": "2026-08-18T15:42:05.475Z",
-      "updatedAt": "2026-08-20T06:32:19.550Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/6edff6216e23.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/61370c151ab7.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/8308768fc836.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/0nt-one/dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/screenshots/app-light.png"
+      "updatedAt": "2026-08-20T09:57:25.326Z"
     },
     {
       "id": "a1swg1159-pixel.dsh-arcaea-theme",
@@ -4420,8 +4119,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/a1swg1159-pixel__dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/38be21aa596f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/a1swg1159-pixel__dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/0201bfda4059.png",
         "https://raw.githubusercontent.com/a1swg1159-pixel/dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/assets/repository-banner.png",
         "https://raw.githubusercontent.com/a1swg1159-pixel/dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/preview.png"
       ],
@@ -4450,14 +4147,9 @@
       "featuredRank": 75,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:51:53.473Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:38.930Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:04.780Z",
       "starsUpdatedAt": "2026-08-16T13:51:53.473Z",
-      "updatedAt": "2026-08-20T06:32:38.930Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/a1swg1159-pixel__dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/38be21aa596f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/a1swg1159-pixel__dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/0201bfda4059.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/a1swg1159-pixel/dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/assets/repository-banner.png"
+      "updatedAt": "2026-08-20T09:58:04.780Z"
     },
     {
       "id": "andy294753951.dsh-plugin-gouden-leeuw-theme",
@@ -4625,9 +4317,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/4ccdfd92c330.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/06d1bf7daba1.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/243fec45dadc.png",
         "https://raw.githubusercontent.com/i1j/dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/assets/theme-dark-1.0.png",
         "https://raw.githubusercontent.com/i1j/dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/assets/theme-light-1.0.png",
         "https://raw.githubusercontent.com/i1j/dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/assets/plankton-1.0.apng"
@@ -4657,15 +4346,9 @@
       "featuredRank": 79,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:52:26.766Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:46.283Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:26.765Z",
       "starsUpdatedAt": "2026-08-16T13:52:26.766Z",
-      "updatedAt": "2026-08-20T06:32:46.283Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/4ccdfd92c330.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/06d1bf7daba1.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/243fec45dadc.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/i1j/dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/assets/theme-dark-1.0.png"
+      "updatedAt": "2026-08-20T09:58:26.765Z"
     },
     {
       "id": "ink5897.dsh-theme-kit",
@@ -4702,14 +4385,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/1d9415a0803b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/4286172cb1b0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/e95b5aceb3e4.png",
         "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/cover.jpg",
         "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/theme-morandi.png",
         "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/theme-macaron.png",
         "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/theme-chinese.png",
-        "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/settings-preset.png"
+        "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/settings-preset.png",
+        "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/settings-background.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -4734,15 +4415,9 @@
       "featuredRank": 80,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:52:31.430Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:46.587Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:28.988Z",
       "starsUpdatedAt": "2026-08-16T13:52:31.430Z",
-      "updatedAt": "2026-08-20T06:32:46.587Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/1d9415a0803b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/4286172cb1b0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/e95b5aceb3e4.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ink5897/dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/docs/cover.jpg"
+      "updatedAt": "2026-08-20T09:58:28.988Z"
     },
     {
       "id": "jack-sun-learner.dsh-image-skin",
@@ -4776,8 +4451,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jack-sun-learner__dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/5b734d6cb78a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jack-sun-learner__dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/43792119e648.png",
         "https://raw.githubusercontent.com/Jack-sun-learner/dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/assets/shot-1.png",
         "https://raw.githubusercontent.com/Jack-sun-learner/dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/assets/shot-2.png"
       ],
@@ -4806,14 +4479,9 @@
       "featuredRank": 81,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:42:47.474Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:26.505Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:30.233Z",
       "starsUpdatedAt": "2026-08-16T13:52:36.792Z",
-      "updatedAt": "2026-08-20T06:32:26.505Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jack-sun-learner__dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/5b734d6cb78a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jack-sun-learner__dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/43792119e648.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Jack-sun-learner/dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/assets/shot-1.png"
+      "updatedAt": "2026-08-20T09:58:30.233Z"
     },
     {
       "id": "kongxiangyiren.dhs-theme-plugin",
@@ -4915,7 +4583,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/laoduu__DeepSeek-Harness-yizi-themes/377676424e0e45f919ab5e8ee54cb1ab0f96da73/1922bd780c28.png",
         "https://raw.githubusercontent.com/laoduu/DeepSeek-Harness-yizi-themes/377676424e0e45f919ab5e8ee54cb1ab0f96da73/assets/dsh-yizi-themes.png",
         "https://raw.githubusercontent.com/laoduu/DeepSeek-Harness-yizi-themes/8964dc67fd77447d450afafc134c8d7421ac6735/assets/dsh-yizi-themes.png"
       ],
@@ -4945,13 +4612,9 @@
       "featuredRank": 83,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:08:27.123Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:47.754Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:39.441Z",
       "starsUpdatedAt": "2026-08-16T13:52:49.212Z",
-      "updatedAt": "2026-08-20T06:32:47.754Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/laoduu__DeepSeek-Harness-yizi-themes/377676424e0e45f919ab5e8ee54cb1ab0f96da73/1922bd780c28.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/laoduu/DeepSeek-Harness-yizi-themes/377676424e0e45f919ab5e8ee54cb1ab0f96da73/assets/dsh-yizi-themes.png"
+      "updatedAt": "2026-08-20T09:58:39.441Z"
     },
     {
       "id": "longyu065.dsh-theme-ti",
@@ -5145,9 +4808,9 @@
       "featuredRank": 86,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16 13:53:22.631000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:27:50.749Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:51.780Z",
       "starsUpdatedAt": "2026-08-16 13:53:22.631000+00:00",
-      "updatedAt": "2026-08-20T06:27:50.749Z"
+      "updatedAt": "2026-08-20T09:58:51.780Z"
     },
     {
       "id": "mtaech.dsh-material-you",
@@ -5183,7 +4846,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/mtaech__dsh-material-you/ed551a54dbf7f666e96b85f650cf01870117aba1/303831835f52.png",
         "https://raw.githubusercontent.com/mtaech/dsh-material-you/ed551a54dbf7f666e96b85f650cf01870117aba1/demo.png"
       ],
       "review": {
@@ -5209,13 +4871,9 @@
       "featuredRank": 87,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:53:28.039Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:50.873Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:52.911Z",
       "starsUpdatedAt": "2026-08-16T13:53:28.039Z",
-      "updatedAt": "2026-08-20T06:32:50.873Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/mtaech__dsh-material-you/ed551a54dbf7f666e96b85f650cf01870117aba1/303831835f52.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/mtaech/dsh-material-you/ed551a54dbf7f666e96b85f650cf01870117aba1/demo.png"
+      "updatedAt": "2026-08-20T09:58:52.911Z"
     },
     {
       "id": "nineandnine-9.dsh-theme-rheostat",
@@ -5317,9 +4975,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/b444d122740a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/b325171f348c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/3030b9fbafe0.png",
         "https://raw.githubusercontent.com/oceanxuikun/dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/assets/screenshot01.png",
         "https://raw.githubusercontent.com/oceanxuikun/dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/assets/screenshot00.png",
         "https://raw.githubusercontent.com/oceanxuikun/dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/assets/screenshot02.png"
@@ -5349,15 +5004,9 @@
       "featuredRank": 89,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:53:35.278Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:52.714Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:58.271Z",
       "starsUpdatedAt": "2026-08-16T13:53:35.278Z",
-      "updatedAt": "2026-08-20T06:32:52.714Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/b444d122740a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/b325171f348c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/3030b9fbafe0.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/oceanxuikun/dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/assets/screenshot01.png"
+      "updatedAt": "2026-08-20T09:58:58.271Z"
     },
     {
       "id": "rainbowdashy.dsh-theme-palettes",
@@ -5523,8 +5172,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakka6868__dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/20b0b738be84.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakka6868__dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/d49a2d9a6ec1.png",
         "https://raw.githubusercontent.com/sakka6868/dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/docs/preview-main.png",
         "https://raw.githubusercontent.com/sakka6868/dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/docs/preview-gallery.png"
       ],
@@ -5553,14 +5200,9 @@
       "featuredRank": 92,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-16T13:53:50.782Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:53.277Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:53.404Z",
       "starsUpdatedAt": "2026-08-18T15:41:48.437Z",
-      "updatedAt": "2026-08-20T06:32:53.277Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakka6868__dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/20b0b738be84.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakka6868__dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/d49a2d9a6ec1.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/sakka6868/dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/docs/preview-main.png"
+      "updatedAt": "2026-08-20T09:57:53.404Z"
     },
     {
       "id": "syopv.dsh-theme-background-center",
@@ -5596,7 +5238,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/syOPV__dsh-theme-background-center/06ff231740697a3f3119be72f5f715677bbbee2c/fc5dbd10316d.jpg",
         "https://raw.githubusercontent.com/syOPV/dsh-theme-background-center/06ff231740697a3f3119be72f5f715677bbbee2c/assets/screenshot.jpg"
       ],
       "review": {
@@ -5622,13 +5263,9 @@
       "featuredRank": 93,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:53:58.612Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:54.148Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:10.372Z",
       "starsUpdatedAt": "2026-08-16T13:53:58.612Z",
-      "updatedAt": "2026-08-20T06:32:54.148Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/syOPV__dsh-theme-background-center/06ff231740697a3f3119be72f5f715677bbbee2c/fc5dbd10316d.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/syOPV/dsh-theme-background-center/06ff231740697a3f3119be72f5f715677bbbee2c/assets/screenshot.jpg"
+      "updatedAt": "2026-08-20T09:59:10.372Z"
     },
     {
       "id": "tpmoonchefryan.dsh-joi-channel-theme",
@@ -5662,14 +5299,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/324d165d7825.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/68354ebf4857.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/f8e95439cf42.png",
         "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/settings-wardrobe.png",
         "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/settings-wardrobe-dark.png",
         "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/new-chat-flowers.png",
         "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/new-chat-library.png",
-        "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/new-chat-flowers-dark.png"
+        "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/new-chat-flowers-dark.png",
+        "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/working-flowers.png",
+        "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/8eb1379dd04f18592f7ae6b833d1890f57e26f24/docs/settings-wardrobe.png",
+        "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/8eb1379dd04f18592f7ae6b833d1890f57e26f24/docs/settings-wardrobe-dark.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -5696,15 +5333,9 @@
       "featuredRank": 94,
       "starsSnapshot": 9,
       "releaseUpdatedAt": "2026-08-20T06:25:22.023Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:56.889Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:12.254Z",
       "starsUpdatedAt": "2026-08-20T06:25:22.023Z",
-      "updatedAt": "2026-08-20T06:32:56.889Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/324d165d7825.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/68354ebf4857.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/f8e95439cf42.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/tpmoonchefryan/dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/docs/settings-wardrobe.png"
+      "updatedAt": "2026-08-20T09:56:12.254Z"
     },
     {
       "id": "wuzhong962-alt.dsh-matrix-theme",
@@ -5835,9 +5466,9 @@
       "featuredRank": 96,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18 15:43:45.074000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:28:15.265Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:18.208Z",
       "starsUpdatedAt": "2026-08-16 13:54:32.014000+00:00",
-      "updatedAt": "2026-08-20T06:28:15.265Z"
+      "updatedAt": "2026-08-20T09:59:18.208Z"
     },
     {
       "id": "adaning.dsh-pixel-skin",
@@ -5873,9 +5504,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/a91be4aad975.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/e4fed3d6dc7f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/9f11b9685c4d.png",
         "https://raw.githubusercontent.com/ADAning/dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/assets/screenshots/new-session.png",
         "https://raw.githubusercontent.com/ADAning/dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/assets/screenshots/working.png",
         "https://raw.githubusercontent.com/ADAning/dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/assets/screenshots/palettes-light.png",
@@ -5906,15 +5534,9 @@
       "featuredRank": 98,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:44:03.968Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:20.643Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:33.353Z",
       "starsUpdatedAt": "2026-08-16T13:54:49.092Z",
-      "updatedAt": "2026-08-20T06:32:20.643Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/a91be4aad975.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/e4fed3d6dc7f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/9f11b9685c4d.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ADAning/dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/assets/screenshots/new-session.png"
+      "updatedAt": "2026-08-20T09:59:33.353Z"
     },
     {
       "id": "cdxdnrf.wishadel-theme",
@@ -5938,10 +5560,10 @@
         "dark"
       ],
       "install": {
-        "target": "github:cdxDNRF/wishadel-theme#02cb6818155dc4816e4de5824a6d6d756b0ba87b",
+        "target": "github:cdxDNRF/wishadel-theme#e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c",
         "version": "0.6.0",
-        "commit": "02cb6818155dc4816e4de5824a6d6d756b0ba87b",
-        "allowBuild": "@cdxdnrf/dsh-client-ui-skin-wishadel@https://codeload.github.com/cdxDNRF/wishadel-theme/tar.gz/02cb6818155dc4816e4de5824a6d6d756b0ba87b"
+        "commit": "e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c",
+        "allowBuild": "@cdxdnrf/dsh-client-ui-skin-wishadel@https://codeload.github.com/cdxDNRF/wishadel-theme/tar.gz/e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c"
       },
       "compatibility": {
         "dsh": "0.1.0-rc.6",
@@ -5950,8 +5572,8 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cdxDNRF__wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/c3d7a856dc7d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cdxDNRF__wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/e9aed2b9941e.png",
+        "https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c/docs/screenshots/conversation.png",
+        "https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c/docs/screenshots/settings.png",
         "https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/docs/screenshots/conversation.png",
         "https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/docs/screenshots/settings.png",
         "https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0/docs/screenshots/conversation.png",
@@ -5979,15 +5601,10 @@
       },
       "featuredRank": 99,
       "starsSnapshot": 0,
-      "releaseUpdatedAt": "2026-08-20T05:09:20.825Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:40.290Z",
+      "releaseUpdatedAt": "2026-08-20T09:59:44.463Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:44.463Z",
       "starsUpdatedAt": "2026-08-16T13:54:53.805Z",
-      "updatedAt": "2026-08-20T06:32:40.290Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cdxDNRF__wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/c3d7a856dc7d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cdxDNRF__wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/e9aed2b9941e.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/docs/screenshots/conversation.png"
+      "updatedAt": "2026-08-20T09:59:44.463Z"
     },
     {
       "id": "charlesaq.dsh-fgo-chaldea",
@@ -6153,9 +5770,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/a7e2345aa86a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/155ec3a25e26.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/8d264d7da245.png",
         "https://raw.githubusercontent.com/dac114514/dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/docs/screenshots/theme.png",
         "https://raw.githubusercontent.com/dac114514/dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/docs/screenshots/theme-window.png",
         "https://raw.githubusercontent.com/dac114514/dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/docs/screenshots/theme-edit.png"
@@ -6183,15 +5797,9 @@
       "featuredRank": 102,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-16T13:55:05.474Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:42.498Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:53.960Z",
       "starsUpdatedAt": "2026-08-16T13:55:05.474Z",
-      "updatedAt": "2026-08-20T06:32:42.498Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/a7e2345aa86a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/155ec3a25e26.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/8d264d7da245.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/dac114514/dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/docs/screenshots/theme.png"
+      "updatedAt": "2026-08-20T09:59:53.960Z"
     },
     {
       "id": "danieltoraji.dsh-skin-kamisato",
@@ -6292,7 +5900,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/gooosie__dsh-whale-bg/2746a7eacba5c0dde28e29d00b6b15f1f2894164/3e89d80013f2.gif",
         "https://raw.githubusercontent.com/gooosie/dsh-whale-bg/2746a7eacba5c0dde28e29d00b6b15f1f2894164/docs/assets/dsh-whale-bg-preview.gif"
       ],
       "review": {
@@ -6320,13 +5927,9 @@
       "featuredRank": 104,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:44:45.240Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:44.584Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:07.218Z",
       "starsUpdatedAt": "2026-08-16T13:55:34.455Z",
-      "updatedAt": "2026-08-20T06:32:44.584Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/gooosie__dsh-whale-bg/2746a7eacba5c0dde28e29d00b6b15f1f2894164/3e89d80013f2.gif"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/gooosie/dsh-whale-bg/2746a7eacba5c0dde28e29d00b6b15f1f2894164/docs/assets/dsh-whale-bg-preview.gif"
+      "updatedAt": "2026-08-20T10:00:07.218Z"
     },
     {
       "id": "gptsapp.dsh-stylevault",
@@ -6363,9 +5966,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/d81c0eb9a2f2.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/4b9015a2c71c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/d1684ef1637d.png",
         "https://raw.githubusercontent.com/GptsApp/dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/docs/screenshots/preview-dark-nord.png",
         "https://raw.githubusercontent.com/GptsApp/dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/docs/screenshots/preview-light-nord.png",
         "https://raw.githubusercontent.com/GptsApp/dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/docs/screenshots/settings-1.png",
@@ -6397,15 +5997,9 @@
       "featuredRank": 105,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:44:47.231Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:24.890Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:08.371Z",
       "starsUpdatedAt": "2026-08-16T13:55:39.547Z",
-      "updatedAt": "2026-08-20T06:32:24.890Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/d81c0eb9a2f2.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/4b9015a2c71c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/d1684ef1637d.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/GptsApp/dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/docs/screenshots/preview-dark-nord.png"
+      "updatedAt": "2026-08-20T10:00:08.371Z"
     },
     {
       "id": "he2way.dsh-task-console",
@@ -6506,8 +6100,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jayliu2025-vip__dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/b3a99705b866.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jayliu2025-vip__dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/1357090fed63.webp",
         "https://raw.githubusercontent.com/Jayliu2025-vip/dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/assets/preview/light.webp",
         "https://raw.githubusercontent.com/Jayliu2025-vip/dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/assets/preview/dark.webp"
       ],
@@ -6536,14 +6128,9 @@
       "featuredRank": 108,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-16T13:55:59.921Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:26.600Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:14.272Z",
       "starsUpdatedAt": "2026-08-16T13:55:59.921Z",
-      "updatedAt": "2026-08-20T06:32:26.600Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jayliu2025-vip__dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/b3a99705b866.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jayliu2025-vip__dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/1357090fed63.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Jayliu2025-vip/dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/assets/preview/light.webp"
+      "updatedAt": "2026-08-20T10:00:14.272Z"
     },
     {
       "id": "jayliu2025-vip.dsh-theme-huluwa",
@@ -6642,7 +6229,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-whale-companion/9fca0908e5a96412f2314c047c2a0bedcdd642b8/61f1015e6fa4.png",
         "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-companion/9fca0908e5a96412f2314c047c2a0bedcdd642b8/assets/screenshots/overview.png"
       ],
       "review": {
@@ -6668,13 +6254,9 @@
       "featuredRank": 110,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:42:59.892Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:27.118Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:40.534Z",
       "starsUpdatedAt": "2026-08-18T15:42:59.892Z",
-      "updatedAt": "2026-08-20T06:32:27.118Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-whale-companion/9fca0908e5a96412f2314c047c2a0bedcdd642b8/61f1015e6fa4.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/LeemanCheung/dsh-whale-companion/9fca0908e5a96412f2314c047c2a0bedcdd642b8/assets/screenshots/overview.png"
+      "updatedAt": "2026-08-20T09:58:40.534Z"
     },
     {
       "id": "lengduan.dsh-815-skin",
@@ -6708,8 +6290,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lengduan__dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/dcb8f6f6f38a.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lengduan__dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/bc45aba2831b.png",
         "https://raw.githubusercontent.com/lengduan/dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/assets/nanjing-surrender-chen-jian.jpg",
         "https://raw.githubusercontent.com/lengduan/dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/docs/preview.png"
       ],
@@ -6739,14 +6319,9 @@
       "featuredRank": 111,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:45:14.378Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:48.285Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:25.139Z",
       "starsUpdatedAt": "2026-08-16T13:56:26.825Z",
-      "updatedAt": "2026-08-20T06:32:48.285Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lengduan__dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/dcb8f6f6f38a.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lengduan__dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/bc45aba2831b.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/lengduan/dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/assets/nanjing-surrender-chen-jian.jpg"
+      "updatedAt": "2026-08-20T10:00:25.139Z"
     },
     {
       "id": "licheng-ma.dsh-wechat-skin",
@@ -6780,7 +6355,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/licheng-ma__dsh-wechat-skin/9528966105ab074631a9b3f7bdf8e2c0a13e3297/27cf701a2c6f.png",
         "https://raw.githubusercontent.com/licheng-ma/dsh-wechat-skin/9528966105ab074631a9b3f7bdf8e2c0a13e3297/docs/preview.png"
       ],
       "review": {
@@ -6806,13 +6380,9 @@
       "featuredRank": 112,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-16T13:56:36.780Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:48.545Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:28.244Z",
       "starsUpdatedAt": "2026-08-16T13:56:36.780Z",
-      "updatedAt": "2026-08-20T06:32:48.545Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/licheng-ma__dsh-wechat-skin/9528966105ab074631a9b3f7bdf8e2c0a13e3297/27cf701a2c6f.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/licheng-ma/dsh-wechat-skin/9528966105ab074631a9b3f7bdf8e2c0a13e3297/docs/preview.png"
+      "updatedAt": "2026-08-20T10:00:28.244Z"
     },
     {
       "id": "linzhuolisoc.dsh-skin-study",
@@ -6844,7 +6414,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/linzhuoliSOC__dsh-skin-study/f37882361478ae9ac63f5d406e8f5e133df5590b/3055dfc69231.png",
         "https://raw.githubusercontent.com/linzhuoliSOC/dsh-skin-study/f37882361478ae9ac63f5d406e8f5e133df5590b/docs/preview.png",
         "https://raw.githubusercontent.com/linzhuoliSOC/dsh-skin-study/65c35fe23ee64a9fa8d8c2813b81a3fba8d218bf/docs/preview.png"
       ],
@@ -6873,13 +6442,9 @@
       "featuredRank": 113,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-20T05:10:02.178Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:48.743Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:29.598Z",
       "starsUpdatedAt": "2026-08-16T13:56:41.045Z",
-      "updatedAt": "2026-08-20T06:32:48.743Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/linzhuoliSOC__dsh-skin-study/f37882361478ae9ac63f5d406e8f5e133df5590b/3055dfc69231.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/linzhuoliSOC/dsh-skin-study/f37882361478ae9ac63f5d406e8f5e133df5590b/docs/preview.png"
+      "updatedAt": "2026-08-20T10:00:29.598Z"
     },
     {
       "id": "mizuhara37.dsh-nene-theme",
@@ -6984,7 +6549,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Morinissleeping__dsh-pnc-theme/07e2e0ebfd2fce33ca9737cdfe42acd6cb512377/7c7249ba8880.png",
         "https://github.com/user-attachments/assets/0d5ca23b-e24e-4ee9-9265-95aedb4b1272"
       ],
       "review": {
@@ -7012,13 +6576,9 @@
       "featuredRank": 115,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-16T13:56:51.169Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:30.720Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:37.425Z",
       "starsUpdatedAt": "2026-08-16T13:56:51.169Z",
-      "updatedAt": "2026-08-20T06:32:30.720Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Morinissleeping__dsh-pnc-theme/07e2e0ebfd2fce33ca9737cdfe42acd6cb512377/7c7249ba8880.png"
-      ],
-      "listScreenshot": "https://github.com/user-attachments/assets/0d5ca23b-e24e-4ee9-9265-95aedb4b1272"
+      "updatedAt": "2026-08-20T10:00:37.425Z"
     },
     {
       "id": "noexcs.dsh-skin-glass",
@@ -7054,8 +6614,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/noexcs__dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/d7328cd03647.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/noexcs__dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/ad584cd4addd.jpg",
         "https://raw.githubusercontent.com/noexcs/dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/screenshots/screenshot_0.jpg",
         "https://raw.githubusercontent.com/noexcs/dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/screenshots/screenshot_1.jpg"
       ],
@@ -7084,14 +6642,9 @@
       "featuredRank": 116,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-16T13:56:56.643Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:52.367Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:43.107Z",
       "starsUpdatedAt": "2026-08-16T13:56:56.643Z",
-      "updatedAt": "2026-08-20T06:32:52.367Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/noexcs__dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/d7328cd03647.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/noexcs__dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/ad584cd4addd.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/noexcs/dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/screenshots/screenshot_0.jpg"
+      "updatedAt": "2026-08-20T10:00:43.107Z"
     },
     {
       "id": "realhacker.dsh-theme-colorizer",
@@ -7126,7 +6679,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RealHacker__dsh-theme-colorizer/7c4152c1956ff87d93d74f928f1cf3a9e60101ca/04fcf2a77b23.jpeg",
         "https://raw.githubusercontent.com/RealHacker/dsh-theme-colorizer/7c4152c1956ff87d93d74f928f1cf3a9e60101ca/asset/dsh-color-theme.jpeg"
       ],
       "review": {
@@ -7154,13 +6706,9 @@
       "featuredRank": 117,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-18T15:41:45.407Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:33.015Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:51.239Z",
       "starsUpdatedAt": "2026-08-18T15:41:45.407Z",
-      "updatedAt": "2026-08-20T06:32:33.015Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RealHacker__dsh-theme-colorizer/7c4152c1956ff87d93d74f928f1cf3a9e60101ca/04fcf2a77b23.jpeg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/RealHacker/dsh-theme-colorizer/7c4152c1956ff87d93d74f928f1cf3a9e60101ca/asset/dsh-color-theme.jpeg"
+      "updatedAt": "2026-08-20T09:57:51.239Z"
     },
     {
       "id": "reluckylucy.dsh-rhine-lab-themo",
@@ -7196,8 +6744,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ReLuckyLucy__dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/79d3d96c7fa0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ReLuckyLucy__dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/db812f42bff6.png",
         "https://raw.githubusercontent.com/ReLuckyLucy/dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/screenshots/light.png",
         "https://raw.githubusercontent.com/ReLuckyLucy/dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/screenshots/dark.png"
       ],
@@ -7224,14 +6770,9 @@
       "featuredRank": 118,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:45:48.008Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:32.898Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:51.090Z",
       "starsUpdatedAt": "2026-08-16T13:57:12.755Z",
-      "updatedAt": "2026-08-20T06:32:32.898Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ReLuckyLucy__dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/79d3d96c7fa0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ReLuckyLucy__dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/db812f42bff6.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ReLuckyLucy/dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/screenshots/light.png"
+      "updatedAt": "2026-08-20T10:00:51.090Z"
     },
     {
       "id": "seekerwxy.dsh-aurora-theme",
@@ -7398,14 +6939,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/d6bcb993bdc9.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/cc49e1ef3ad3.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/911cc3436296.gif",
         "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/preview-home.png",
         "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/preview-conversation.png",
         "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/state-idle.gif",
         "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/state-typing.gif",
-        "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/state-thinking.gif"
+        "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/state-thinking.gif",
+        "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/223a27aefedd1ad221083d065754614401eade80/docs/images/preview-home.png",
+        "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/223a27aefedd1ad221083d065754614401eade80/docs/images/preview-conversation.png",
+        "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/223a27aefedd1ad221083d065754614401eade80/docs/images/state-idle.gif"
       ],
       "review": {
         "compatibility": "unverified",
@@ -7432,15 +6973,9 @@
       "featuredRank": 121,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T05:07:51.150Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:55.106Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:54.878Z",
       "starsUpdatedAt": "2026-08-20T05:07:51.150Z",
-      "updatedAt": "2026-08-20T06:32:55.106Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/d6bcb993bdc9.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/cc49e1ef3ad3.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/911cc3436296.gif"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/thjyy/dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/docs/images/preview-home.png"
+      "updatedAt": "2026-08-20T09:57:54.878Z"
     },
     {
       "id": "tiantyu.dsh-skin-toggle",
@@ -7607,9 +7142,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/9bee1198d94f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/0c653a2510a4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/a2561f6c70a5.png",
         "https://raw.githubusercontent.com/WuWL-98/dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/docs/main.png",
         "https://raw.githubusercontent.com/WuWL-98/dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/docs/settings.png",
         "https://raw.githubusercontent.com/WuWL-98/dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/docs/conversation.png"
@@ -7637,15 +7169,9 @@
       "featuredRank": 125,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-16T13:58:11.377Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:37.303Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:13.858Z",
       "starsUpdatedAt": "2026-08-20T05:08:56.600Z",
-      "updatedAt": "2026-08-20T06:32:37.303Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/9bee1198d94f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/0c653a2510a4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/a2561f6c70a5.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/WuWL-98/dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/docs/main.png"
+      "updatedAt": "2026-08-20T09:59:13.858Z"
     },
     {
       "id": "xiaoyanzi191.dsh-premium-themes",
@@ -7683,9 +7209,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/9ebead527a1e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/1cd9a934cc80.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/3c5ad53464e6.png",
         "https://raw.githubusercontent.com/xiaoyanzi191/dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/docs/screenshots/palette-row.png",
         "https://raw.githubusercontent.com/xiaoyanzi191/dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/docs/screenshots/paper-gold.png",
         "https://raw.githubusercontent.com/xiaoyanzi191/dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/docs/screenshots/tokyo-night.png",
@@ -7717,15 +7240,9 @@
       "featuredRank": 126,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:46:30.744Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:59.022Z",
+      "metadataUpdatedAt": "2026-08-20T10:01:17.120Z",
       "starsUpdatedAt": "2026-08-16T13:58:16.091Z",
-      "updatedAt": "2026-08-20T06:32:59.022Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/9ebead527a1e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/1cd9a934cc80.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/3c5ad53464e6.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/xiaoyanzi191/dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/docs/screenshots/palette-row.png"
+      "updatedAt": "2026-08-20T10:01:17.120Z"
     },
     {
       "id": "youyli03.dsh-palenight-theme",
@@ -7760,8 +7277,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/youyli03__dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/5398cd56b6a8.jpeg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/youyli03__dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/467c1c3cea6d.jpeg",
         "https://raw.githubusercontent.com/youyli03/dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/screenshots/light.jpeg",
         "https://raw.githubusercontent.com/youyli03/dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/screenshots/dark.jpeg"
       ],
@@ -7790,14 +7305,9 @@
       "featuredRank": 127,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-16T13:58:24.026Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:59.893Z",
+      "metadataUpdatedAt": "2026-08-20T10:01:25.222Z",
       "starsUpdatedAt": "2026-08-16T13:58:24.026Z",
-      "updatedAt": "2026-08-20T06:32:59.893Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/youyli03__dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/5398cd56b6a8.jpeg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/youyli03__dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/467c1c3cea6d.jpeg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/youyli03/dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/screenshots/light.jpeg"
+      "updatedAt": "2026-08-20T10:01:25.222Z"
     },
     {
       "id": "yuqisun.dsh-theme-machine",
@@ -7832,8 +7342,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yuqisun__dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/115439edfd98.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yuqisun__dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/76cdff45d75b.png",
         "https://raw.githubusercontent.com/yuqisun/dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/screenshots/demo1.png",
         "https://raw.githubusercontent.com/yuqisun/dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/screenshots/demo2.png"
       ],
@@ -7863,14 +7371,9 @@
       "featuredRank": 128,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:46:41.776Z",
-      "metadataUpdatedAt": "2026-08-20T06:33:00.303Z",
+      "metadataUpdatedAt": "2026-08-20T10:01:26.264Z",
       "starsUpdatedAt": "2026-08-16T13:58:28.052Z",
-      "updatedAt": "2026-08-20T06:33:00.303Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yuqisun__dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/115439edfd98.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yuqisun__dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/76cdff45d75b.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/yuqisun/dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/screenshots/demo1.png"
+      "updatedAt": "2026-08-20T10:01:26.264Z"
     },
     {
       "id": "zjuzhiyucai.dsh-ivory",
@@ -7894,20 +7397,21 @@
         "dark"
       ],
       "install": {
-        "target": "github:ZJUZhiyuCai/dsh-ivory#3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317",
-        "version": "0.2.4",
-        "commit": "3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317"
+        "target": "github:ZJUZhiyuCai/dsh-ivory#4cfd7236d4ef062946e54f43eb6d5a8f53407ab1",
+        "version": "0.2.5",
+        "commit": "4cfd7236d4ef062946e54f43eb6d5a8f53407ab1"
       },
       "compatibility": {
-        "dsh": "0.1.0-rc.6",
+        "dsh": "0.1.0-rc.7",
         "platform": [
           "web"
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/ecc3a4b73867.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/af7aee1db50b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/8fac46f127fa.png",
+        "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/hero-light.png",
+        "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/hero-dark.png",
+        "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/conversation-light.png",
+        "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/mobile-light.png",
         "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/hero-light.png",
         "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/hero-dark.png",
         "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/conversation-light.png",
@@ -7935,16 +7439,10 @@
       },
       "featuredRank": 129,
       "starsSnapshot": 1,
-      "releaseUpdatedAt": "2026-08-18T15:43:57.184Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:37.695Z",
+      "releaseUpdatedAt": "2026-08-20T09:59:29.826Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:29.826Z",
       "starsUpdatedAt": "2026-08-18T15:43:57.184Z",
-      "updatedAt": "2026-08-20T06:32:37.695Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/ecc3a4b73867.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/af7aee1db50b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/8fac46f127fa.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/hero-light.png"
+      "updatedAt": "2026-08-20T09:59:29.826Z"
     },
     {
       "id": "ewnscat-ya.dsh-client-ui-skin-denia",
@@ -7981,8 +7479,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ewnscat-ya__dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/364d884e256e.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ewnscat-ya__dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/a5d4d4fa6e03.webp",
         "https://raw.githubusercontent.com/Ewnscat-ya/dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/preview/light.webp",
         "https://raw.githubusercontent.com/Ewnscat-ya/dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/preview/dark.webp"
       ],
@@ -8010,14 +7506,9 @@
       "featuredRank": 133,
       "starsSnapshot": 22,
       "releaseUpdatedAt": "2026-08-18T15:39:04.526Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:24.358Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:48.506Z",
       "starsUpdatedAt": "2026-08-20T05:06:02.269Z",
-      "updatedAt": "2026-08-20T06:32:24.358Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ewnscat-ya__dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/364d884e256e.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ewnscat-ya__dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/a5d4d4fa6e03.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Ewnscat-ya/dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/preview/light.webp"
+      "updatedAt": "2026-08-20T09:55:48.506Z"
     },
     {
       "id": "hachimi-ai.dsh-aemeath",
@@ -8053,8 +7544,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hachimi-ai__dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/ff3e844f80c0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hachimi-ai__dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/e2808a184dc4.png",
         "https://raw.githubusercontent.com/hachimi-ai/dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/image/image1.png",
         "https://github.com/user-attachments/assets/da2c1a8e-5ea8-4e1c-81d4-4c3f5cfffc83"
       ],
@@ -8082,14 +7571,9 @@
       "featuredRank": 134,
       "starsSnapshot": 5,
       "releaseUpdatedAt": "2026-08-16T16:37:51Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:45.439Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:33.210Z",
       "starsUpdatedAt": "2026-08-20T05:07:43.055Z",
-      "updatedAt": "2026-08-20T06:32:45.439Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hachimi-ai__dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/ff3e844f80c0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hachimi-ai__dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/e2808a184dc4.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/hachimi-ai/dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/image/image1.png"
+      "updatedAt": "2026-08-20T09:56:33.210Z"
     },
     {
       "id": "ayase34.gal-view",
@@ -8124,7 +7608,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ayase34__gal-view/d002fe0e7051c618a2665af3c653f9838cd6aa8a/6cb3d89f0dac.png",
         "https://raw.githubusercontent.com/Ayase34/gal-view/d002fe0e7051c618a2665af3c653f9838cd6aa8a/image.png"
       ],
       "review": {
@@ -8150,15 +7633,11 @@
         "commercialUse": true
       },
       "featuredRank": 135,
-      "starsSnapshot": 106,
+      "starsSnapshot": 107,
       "releaseUpdatedAt": "2026-08-16T09:00:49+09:00",
-      "metadataUpdatedAt": "2026-08-20T06:32:21.450Z",
-      "starsUpdatedAt": "2026-08-20T05:05:45.706Z",
-      "updatedAt": "2026-08-20T06:32:21.450Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ayase34__gal-view/d002fe0e7051c618a2665af3c653f9838cd6aa8a/6cb3d89f0dac.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Ayase34/gal-view/d002fe0e7051c618a2665af3c653f9838cd6aa8a/image.png"
+      "metadataUpdatedAt": "2026-08-20T09:55:28.757Z",
+      "starsUpdatedAt": "2026-08-20T09:55:28.757Z",
+      "updatedAt": "2026-08-20T09:55:28.757Z"
     },
     {
       "id": "featherhunter.dsh-opencode-palette",
@@ -8183,9 +7662,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:FeatherHunter/dsh-opencode-palette#5aeadca70606ceb38f94080694e0c9fe47d4b10f&path:package",
+        "target": "github:FeatherHunter/dsh-opencode-palette#e7460a9651e19ea02a7e9bc789810ab8b2a1d5e0&path:package",
         "version": "1.6.4",
-        "commit": "5aeadca70606ceb38f94080694e0c9fe47d4b10f"
+        "commit": "e7460a9651e19ea02a7e9bc789810ab8b2a1d5e0"
       },
       "compatibility": {
         "dsh": "unverified",
@@ -8228,10 +7707,10 @@
       },
       "featuredRank": 139,
       "starsSnapshot": 7,
-      "releaseUpdatedAt": "2026-08-18T12:25:52+08:00",
+      "releaseUpdatedAt": "2026-08-20T09:56:16.140Z",
       "metadataUpdatedAt": "2026-08-18T15:40:14.498Z",
       "starsUpdatedAt": "2026-08-20T05:06:31.308Z",
-      "updatedAt": "2026-08-20T05:06:31.308Z"
+      "updatedAt": "2026-08-20T09:56:16.140Z"
     },
     {
       "id": "nagi-ovo.dsh-ads",
@@ -8266,14 +7745,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/963b54637a53.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/1776480921bb.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/df0d8c1e4e25.webp",
         "https://raw.githubusercontent.com/Nagi-ovo/dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/assets/screenshot.webp",
         "https://raw.githubusercontent.com/Nagi-ovo/dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/assets/english-mode.png",
         "https://raw.githubusercontent.com/Nagi-ovo/dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/assets/settings.webp",
         "https://raw.githubusercontent.com/Nagi-ovo/dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/assets/social-preview.jpg",
-        "https://dshfind.com/api/card/Nagi-ovo/dsh-ads?lang=zh"
+        "https://dshfind.com/api/card/Nagi-ovo/dsh-ads?lang=zh",
+        "https://raw.githubusercontent.com/Nagi-ovo/dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/assets/reward-gate.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -8296,17 +7773,11 @@
         "commercialUse": true
       },
       "featuredRank": 142,
-      "starsSnapshot": 514,
+      "starsSnapshot": 516,
       "releaseUpdatedAt": "2026-08-18T02:28:44+01:00",
-      "metadataUpdatedAt": "2026-08-20T06:32:31.248Z",
-      "starsUpdatedAt": "2026-08-20T05:05:39.098Z",
-      "updatedAt": "2026-08-20T06:32:31.248Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/963b54637a53.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/1776480921bb.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/df0d8c1e4e25.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Nagi-ovo/dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/assets/screenshot.webp"
+      "metadataUpdatedAt": "2026-08-20T09:55:22.655Z",
+      "starsUpdatedAt": "2026-08-20T09:55:22.655Z",
+      "updatedAt": "2026-08-20T09:55:22.655Z"
     },
     {
       "id": "rison114514.dsh-endfield-ui",
@@ -8343,8 +7814,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/2fd1a8fe59fc.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/914cfb5da9e1.jpg",
         "https://raw.githubusercontent.com/rison114514/dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/dsh-packaged-final.jpg",
         "https://raw.githubusercontent.com/rison114514/dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/dsh-settings-final.jpg",
         "https://raw.githubusercontent.com/rison114514/dsh-endfield-ui/7993d60782658e7c30a5ff421a3f621c1aba9487/dsh-packaged-final.jpg",
@@ -8375,16 +7844,11 @@
         "notice": "插件代码在 package.json 中声明为 MIT；仓库同时说明第三方字体、游戏视觉素材和品牌/角色素材的授权范围仍需逐项确认，因此市场不将整体素材视为可商业再分发。"
       },
       "featuredRank": 143,
-      "starsSnapshot": 20,
+      "starsSnapshot": 22,
       "releaseUpdatedAt": "2026-08-20T05:06:20.536Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:53.063Z",
-      "starsUpdatedAt": "2026-08-20T05:06:20.536Z",
-      "updatedAt": "2026-08-20T06:32:53.063Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/2fd1a8fe59fc.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/914cfb5da9e1.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/rison114514/dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/dsh-packaged-final.jpg"
+      "metadataUpdatedAt": "2026-08-20T09:55:51.419Z",
+      "starsUpdatedAt": "2026-08-20T09:55:51.419Z",
+      "updatedAt": "2026-08-20T09:55:51.419Z"
     },
     {
       "id": "niiang.dsh-kimino-theme",
@@ -8421,14 +7885,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/a772df2ec4a5.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/39080628bbd4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/98896630d591.png",
         "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/home-hero.png",
         "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/sidebar.png",
         "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/chat-main.png",
         "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/home-hero.png",
-        "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/sidebar.png"
+        "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/sidebar.png",
+        "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/eda0aef6141cf13e4bb123a4749696fe045c349c/docs/screenshots/chat-main.png"
       ],
       "review": {
         "compatibility": "unverified",
@@ -8455,15 +7917,9 @@
       "featuredRank": 145,
       "starsSnapshot": 17,
       "releaseUpdatedAt": "2026-08-20T05:06:18.924Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:52.236Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:08.852Z",
       "starsUpdatedAt": "2026-08-20T06:25:18.666Z",
-      "updatedAt": "2026-08-20T06:32:52.236Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/a772df2ec4a5.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/39080628bbd4.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/98896630d591.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/niiang/dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/docs/screenshots/home-hero.png"
+      "updatedAt": "2026-08-20T09:56:08.852Z"
     },
     {
       "id": "charrywhite.dsh-sticky-notes",
@@ -8496,9 +7952,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/8fe44a5facb0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/074f9ee979b1.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/317e42125968.png",
         "https://raw.githubusercontent.com/charrywhite/dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/headline.png",
         "https://raw.githubusercontent.com/charrywhite/dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/interface4.PNG",
         "https://raw.githubusercontent.com/charrywhite/dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/skins.png"
@@ -8528,15 +7981,9 @@
       "featuredRank": 146,
       "starsSnapshot": 5,
       "releaseUpdatedAt": "2026-08-18T15:39:58.583Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:40.537Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:32.185Z",
       "starsUpdatedAt": "2026-08-18T15:39:58.583Z",
-      "updatedAt": "2026-08-20T06:32:40.537Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/8fe44a5facb0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/074f9ee979b1.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/317e42125968.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/charrywhite/dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/headline.png"
+      "updatedAt": "2026-08-20T09:56:32.185Z"
     },
     {
       "id": "sodazilla-zzz.dsh-liquid-glass-balance-card",
@@ -8572,8 +8019,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SoDaZilla-zzz__dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/247431a435ee.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SoDaZilla-zzz__dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/41e2db6c103d.gif",
         "https://raw.githubusercontent.com/SoDaZilla-zzz/dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/docs/cover.jpg",
         "https://raw.githubusercontent.com/SoDaZilla-zzz/dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/docs/demo.gif",
         "https://raw.githubusercontent.com/SoDaZilla-zzz/dsh-liquid-glass-balance-card/b3a0dd6525f86d8fb2db53cfb71793ce2494587e/docs/cover.jpg",
@@ -8602,14 +8047,9 @@
       "featuredRank": 147,
       "starsSnapshot": 5,
       "releaseUpdatedAt": "2026-08-20T05:06:48.636Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:34.666Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:42.530Z",
       "starsUpdatedAt": "2026-08-18T15:40:22.365Z",
-      "updatedAt": "2026-08-20T06:32:34.666Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SoDaZilla-zzz__dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/247431a435ee.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SoDaZilla-zzz__dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/41e2db6c103d.gif"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/SoDaZilla-zzz/dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/docs/cover.jpg"
+      "updatedAt": "2026-08-20T09:56:42.530Z"
     },
     {
       "id": "ddbj-hub.dsh-wallpaper-skin",
@@ -8711,9 +8151,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/b83bcbb2a11b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/fe0cc32c7745.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/0e87cb8d22cc.jpg",
         "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/docs/screenshots/01-wallpaper.jpg",
         "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/docs/screenshots/02-boot.jpg",
         "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/docs/screenshots/03-firefly.jpg",
@@ -8745,15 +8182,9 @@
       "featuredRank": 153,
       "starsSnapshot": 7,
       "releaseUpdatedAt": "2026-08-20T05:06:46.763Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:29.714Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:40.089Z",
       "starsUpdatedAt": "2026-08-20T06:25:47.963Z",
-      "updatedAt": "2026-08-20T06:32:29.714Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/b83bcbb2a11b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/fe0cc32c7745.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/0e87cb8d22cc.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Liu-ZA-81/dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/docs/screenshots/01-wallpaper.jpg"
+      "updatedAt": "2026-08-20T09:56:40.089Z"
     },
     {
       "id": "ymh0000123.dsh-theme-endfield",
@@ -8815,11 +8246,11 @@
         "commercialUse": true
       },
       "featuredRank": 154,
-      "starsSnapshot": 6,
+      "starsSnapshot": 7,
       "releaseUpdatedAt": "2026-08-18 15:42:02.669000+00:00",
       "metadataUpdatedAt": "2026-08-18 15:42:02.669000+00:00",
-      "starsUpdatedAt": "2026-08-20T05:06:36.282Z",
-      "updatedAt": "2026-08-20T05:06:36.282Z"
+      "starsUpdatedAt": "2026-08-20T09:56:21.746Z",
+      "updatedAt": "2026-08-20T09:56:21.746Z"
     },
     {
       "id": "aik358.dsh-anchored-monitor",
@@ -8853,7 +8284,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Aik358__dsh-anchored-monitor/8cb863fa50c3d17dec2683a247b93f90deeb5a16/dbba1a8220b6.png",
         "https://raw.githubusercontent.com/Aik358/dsh-anchored-monitor/8cb863fa50c3d17dec2683a247b93f90deeb5a16/docs/dashboard.png",
         "https://raw.githubusercontent.com/Aik358/dsh-anchored-monitor/133e0adc2f11a2eb0844683b9405eb88b97d52c0/docs/dashboard.png"
       ],
@@ -8878,15 +8308,11 @@
         "commercialUse": true
       },
       "featuredRank": 155,
-      "starsSnapshot": 3,
+      "starsSnapshot": 4,
       "releaseUpdatedAt": "2026-08-20T05:07:05.976Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:21.178Z",
-      "starsUpdatedAt": "2026-08-20T05:07:05.976Z",
-      "updatedAt": "2026-08-20T06:32:21.178Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Aik358__dsh-anchored-monitor/8cb863fa50c3d17dec2683a247b93f90deeb5a16/dbba1a8220b6.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Aik358/dsh-anchored-monitor/8cb863fa50c3d17dec2683a247b93f90deeb5a16/docs/dashboard.png"
+      "metadataUpdatedAt": "2026-08-20T09:56:50.641Z",
+      "starsUpdatedAt": "2026-08-20T09:56:50.641Z",
+      "updatedAt": "2026-08-20T09:56:50.641Z"
     },
     {
       "id": "chouxiaohuai.uiskin-theme",
@@ -8922,8 +8348,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chouxiaohuai__uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/667a8d6a1eca.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chouxiaohuai__uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/18ecf8a1a2fa.jpg",
         "https://raw.githubusercontent.com/chouxiaohuai/uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/assets/preview.jpg",
         "https://raw.githubusercontent.com/chouxiaohuai/uiskin-theme/c049c384087a797689d0d82e79bb047b9e4236f4/assets/preview.jpg"
       ],
@@ -8952,14 +8376,9 @@
       "featuredRank": 159,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:08:04.519Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:40.669Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:11.892Z",
       "starsUpdatedAt": "2026-08-18T15:42:23.724Z",
-      "updatedAt": "2026-08-20T06:32:40.669Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chouxiaohuai__uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/667a8d6a1eca.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chouxiaohuai__uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/18ecf8a1a2fa.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/chouxiaohuai/uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/assets/preview.jpg"
+      "updatedAt": "2026-08-20T09:58:11.892Z"
     },
     {
       "id": "hyposelen1a.dsh-columbina-theme",
@@ -8995,8 +8414,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hyposelen1a__dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/7ea4a4807e4b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hyposelen1a__dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/6307251e7728.png",
         "https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/docs/screenshot-light.png",
         "https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/docs/screenshot-dark.png",
         "https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/00b8e72e5d40bbaf62959e5a5bef5108beded9e0/docs/screenshot-light.png",
@@ -9025,14 +8442,9 @@
       "featuredRank": 160,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:08:15.274Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:46.102Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:25.769Z",
       "starsUpdatedAt": "2026-08-18T15:42:41.150Z",
-      "updatedAt": "2026-08-20T06:32:46.102Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hyposelen1a__dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/7ea4a4807e4b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hyposelen1a__dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/6307251e7728.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/hyposelen1a/dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/docs/screenshot-light.png"
+      "updatedAt": "2026-08-20T09:58:25.769Z"
     },
     {
       "id": "jungeer.dsh-theme-stardew",
@@ -9067,8 +8479,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/jungeer__dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/db9d8ed579cf.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/jungeer__dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/83d214c65f95.jpg",
         "https://raw.githubusercontent.com/jungeer/dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/docs/preview-day.jpg",
         "https://raw.githubusercontent.com/jungeer/dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/docs/preview-night.jpg"
       ],
@@ -9097,14 +8507,9 @@
       "featuredRank": 161,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:42:49.178Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:46.818Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:31.321Z",
       "starsUpdatedAt": "2026-08-18T15:42:49.178Z",
-      "updatedAt": "2026-08-20T06:32:46.818Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/jungeer__dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/db9d8ed579cf.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/jungeer__dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/83d214c65f95.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/jungeer/dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/docs/preview-day.jpg"
+      "updatedAt": "2026-08-20T09:58:31.321Z"
     },
     {
       "id": "juryorca.dsh-custom-theme-import",
@@ -9329,9 +8734,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/a6ebf0060d27.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/6f0ead310d16.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/a67c82b7faed.png",
         "https://raw.githubusercontent.com/zsyayo112/dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/docs/screenshot-c137-dark.png",
         "https://raw.githubusercontent.com/zsyayo112/dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/docs/screenshot-meeseeks-light.png",
         "https://raw.githubusercontent.com/zsyayo112/dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/docs/screenshot-settings.png"
@@ -9361,15 +8763,9 @@
       "featuredRank": 166,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:43:58.602Z",
-      "metadataUpdatedAt": "2026-08-20T06:33:02.421Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:30.849Z",
       "starsUpdatedAt": "2026-08-18T15:43:58.602Z",
-      "updatedAt": "2026-08-20T06:33:02.421Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/a6ebf0060d27.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/6f0ead310d16.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/a67c82b7faed.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/zsyayo112/dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/docs/screenshot-c137-dark.png"
+      "updatedAt": "2026-08-20T09:59:30.849Z"
     },
     {
       "id": "1mlightyears.dsh-theme-synthwave",
@@ -9406,8 +8802,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/1MLightyears__dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/de3891172afb.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/1MLightyears__dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/ceac5d4e03e6.png",
         "https://raw.githubusercontent.com/1MLightyears/dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/showcase.png",
         "https://raw.githubusercontent.com/1MLightyears/dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/settings.png"
       ],
@@ -9436,14 +8830,9 @@
       "featuredRank": 167,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:44:00.135Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:19.997Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:31.904Z",
       "starsUpdatedAt": "2026-08-18T15:44:00.135Z",
-      "updatedAt": "2026-08-20T06:32:19.997Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/1MLightyears__dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/de3891172afb.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/1MLightyears__dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/ceac5d4e03e6.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/1MLightyears/dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/showcase.png"
+      "updatedAt": "2026-08-20T09:59:31.904Z"
     },
     {
       "id": "54088lp.dsh-kafka-ui",
@@ -9478,7 +8867,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/54088lp__dsh-kafka-ui/3cc47b912634897a878b2d201980c01edc86a804/f255aef984c8.png",
         "https://github.com/user-attachments/assets/037098e7-a30d-4c55-9da5-4763ace011f8"
       ],
       "review": {
@@ -9506,13 +8894,9 @@
       "featuredRank": 168,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:44:02.099Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:20.347Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:02.945Z",
       "starsUpdatedAt": "2026-08-20T05:07:57.674Z",
-      "updatedAt": "2026-08-20T06:32:20.347Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/54088lp__dsh-kafka-ui/3cc47b912634897a878b2d201980c01edc86a804/f255aef984c8.png"
-      ],
-      "listScreenshot": "https://github.com/user-attachments/assets/037098e7-a30d-4c55-9da5-4763ace011f8"
+      "updatedAt": "2026-08-20T09:58:02.945Z"
     },
     {
       "id": "baihejiangnan.dsh-custom-wallpaper",
@@ -9547,8 +8931,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/baihejiangnan__dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/7b14123994bc.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/baihejiangnan__dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/4656e215bac6.png",
         "https://raw.githubusercontent.com/baihejiangnan/dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/assets/wallpaper-1.png",
         "https://raw.githubusercontent.com/baihejiangnan/dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/assets/wallpaper-2.png"
       ],
@@ -9577,14 +8959,9 @@
       "featuredRank": 169,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:44:10.019Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:39.261Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:37.580Z",
       "starsUpdatedAt": "2026-08-18T15:44:10.019Z",
-      "updatedAt": "2026-08-20T06:32:39.261Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/baihejiangnan__dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/7b14123994bc.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/baihejiangnan__dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/4656e215bac6.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/baihejiangnan/dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/assets/wallpaper-1.png"
+      "updatedAt": "2026-08-20T09:59:37.580Z"
     },
     {
       "id": "bpz0726.dsh-bestui",
@@ -9882,7 +9259,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/crack-time__dsh-web-ui-skin/1300b594d16b292519a109385ad360247b6fba26/3af153abd2ca.jpg",
         "https://raw.githubusercontent.com/crack-time/dsh-web-ui-skin/1300b594d16b292519a109385ad360247b6fba26/docs/screenshot.jpg"
       ],
       "review": {
@@ -9908,13 +9284,9 @@
       "featuredRank": 174,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:44:25.553Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:41.091Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:52.898Z",
       "starsUpdatedAt": "2026-08-18T15:44:25.553Z",
-      "updatedAt": "2026-08-20T06:32:41.091Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/crack-time__dsh-web-ui-skin/1300b594d16b292519a109385ad360247b6fba26/3af153abd2ca.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/crack-time/dsh-web-ui-skin/1300b594d16b292519a109385ad360247b6fba26/docs/screenshot.jpg"
+      "updatedAt": "2026-08-20T09:59:52.898Z"
     },
     {
       "id": "eachsheep.dsh-valley-pixel-skin",
@@ -9939,9 +9311,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:EachSheep/dsh-valley-pixel-skin#f6f4f7b0adb3b52620ceb0b7ea419d80b969b588",
+        "target": "github:EachSheep/dsh-valley-pixel-skin#23e0460d221a09deeb9e7fd3f7bbb438bc441b4c",
         "version": "0.1.0",
-        "commit": "f6f4f7b0adb3b52620ceb0b7ea419d80b969b588"
+        "commit": "23e0460d221a09deeb9e7fd3f7bbb438bc441b4c"
       },
       "compatibility": {
         "dsh": "0.1.0-rc.6",
@@ -9950,7 +9322,7 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EachSheep__dsh-valley-pixel-skin/f6f4f7b0adb3b52620ceb0b7ea419d80b969b588/b7c51dd8c7b2.png",
+        "https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/23e0460d221a09deeb9e7fd3f7bbb438bc441b4c/preview/valley-spring-main.png",
         "https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/f6f4f7b0adb3b52620ceb0b7ea419d80b969b588/preview/valley-spring-main.png",
         "https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/e746c941ffba2dd11ead96b50bc8c2964e9fef8b/preview/valley-spring-main.png"
       ],
@@ -9976,14 +9348,10 @@
       },
       "featuredRank": 175,
       "starsSnapshot": 0,
-      "releaseUpdatedAt": "2026-08-20T05:09:33.514Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:23.418Z",
+      "releaseUpdatedAt": "2026-08-20T09:59:58.277Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:58.277Z",
       "starsUpdatedAt": "2026-08-18T15:44:34.423Z",
-      "updatedAt": "2026-08-20T06:32:23.418Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EachSheep__dsh-valley-pixel-skin/f6f4f7b0adb3b52620ceb0b7ea419d80b969b588/b7c51dd8c7b2.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/f6f4f7b0adb3b52620ceb0b7ea419d80b969b588/preview/valley-spring-main.png"
+      "updatedAt": "2026-08-20T09:59:58.277Z"
     },
     {
       "id": "h-table.dsh-bg-tool",
@@ -10018,14 +9386,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/0967c5e7c488.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/d9f029fd0d67.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/303653506893.png",
         "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/hero.png",
         "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/dsh-mermaid-original.png",
         "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/dsh-mermaid-general.png",
         "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/dsh-mermaid-portrait.png",
-        "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/gui-bg-card.png"
+        "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/gui-bg-card.png",
+        "https://raw.githubusercontent.com/H-table/dsh-bg-tool/403b767f84b5168ed37aa1f75304a7e324428959/assets/hero.png",
+        "https://raw.githubusercontent.com/H-table/dsh-bg-tool/403b767f84b5168ed37aa1f75304a7e324428959/assets/dsh-mermaid-original.png",
+        "https://raw.githubusercontent.com/H-table/dsh-bg-tool/403b767f84b5168ed37aa1f75304a7e324428959/assets/dsh-mermaid-general.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -10052,15 +9420,9 @@
       "featuredRank": 177,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-20T05:09:43.612Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:25.879Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:09.824Z",
       "starsUpdatedAt": "2026-08-18T15:44:48.848Z",
-      "updatedAt": "2026-08-20T06:32:25.879Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/0967c5e7c488.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/d9f029fd0d67.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/303653506893.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/H-table/dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/assets/hero.png"
+      "updatedAt": "2026-08-20T10:00:09.824Z"
     },
     {
       "id": "hanyi7867069-create.dsh-moonrise",
@@ -10157,7 +9519,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/justintangsysu__dsh-amadeus-skin/7f074e5d54b60fbfb423d11d096c5b054607c026/f53f07b39227.webp",
         "https://raw.githubusercontent.com/justintangsysu/dsh-amadeus-skin/7f074e5d54b60fbfb423d11d096c5b054607c026/preview/preview.webp"
       ],
       "review": {
@@ -10185,13 +9546,9 @@
       "featuredRank": 181,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:45:09.310Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:46.924Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:21.114Z",
       "starsUpdatedAt": "2026-08-18T15:45:09.310Z",
-      "updatedAt": "2026-08-20T06:32:46.924Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/justintangsysu__dsh-amadeus-skin/7f074e5d54b60fbfb423d11d096c5b054607c026/f53f07b39227.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/justintangsysu/dsh-amadeus-skin/7f074e5d54b60fbfb423d11d096c5b054607c026/preview/preview.webp"
+      "updatedAt": "2026-08-20T10:00:21.114Z"
     },
     {
       "id": "lkdx0220.genshin-odette-skin-dsh",
@@ -10230,9 +9587,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/87528228c92b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/b1d4166746f7.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/2514d0d2224c.jpg",
         "https://raw.githubusercontent.com/lkdx0220/Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/assets/bg-light.jpg",
         "https://raw.githubusercontent.com/lkdx0220/Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/assets/bg-dark.jpg",
         "https://raw.githubusercontent.com/lkdx0220/Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/assets/deco-sidebar.jpg"
@@ -10262,15 +9616,9 @@
       "featuredRank": 182,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:45:23.237Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:48.958Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:31.506Z",
       "starsUpdatedAt": "2026-08-18T15:45:23.237Z",
-      "updatedAt": "2026-08-20T06:32:48.958Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/87528228c92b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/b1d4166746f7.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/2514d0d2224c.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/lkdx0220/Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/assets/bg-light.jpg"
+      "updatedAt": "2026-08-20T10:00:31.506Z"
     },
     {
       "id": "lyq3.dsh-skin-nebula",
@@ -10308,14 +9656,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/1792ec757772.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/107f44a4277e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/79c78248e4cb.png",
         "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/ninja-dark.png",
         "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/ninja-light.png",
         "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/sakura-dark.png",
         "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/sakura-light.png",
-        "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/bamboo-dark.png"
+        "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/bamboo-dark.png",
+        "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/bamboo-light.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -10340,15 +9686,9 @@
       "featuredRank": 183,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:45:26.029Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:50.051Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:34.468Z",
       "starsUpdatedAt": "2026-08-18T15:45:26.029Z",
-      "updatedAt": "2026-08-20T06:32:50.051Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/1792ec757772.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/107f44a4277e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/79c78248e4cb.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/lyq3/dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/assets/ninja-dark.png"
+      "updatedAt": "2026-08-20T10:00:34.468Z"
     },
     {
       "id": "nlqh7.dsh-beautify",
@@ -10450,7 +9790,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ossFrankFrank__dsh-dracula-theme/684d09a59a62e4180ac087918cb4f6d5aeffef9f/f5372d57bd76.png",
         "https://raw.githubusercontent.com/ossFrankFrank/dsh-dracula-theme/684d09a59a62e4180ac087918cb4f6d5aeffef9f/assets/preview.png"
       ],
       "review": {
@@ -10476,13 +9815,9 @@
       "featuredRank": 186,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:45:38.721Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:52.735Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:44.262Z",
       "starsUpdatedAt": "2026-08-18T15:45:38.721Z",
-      "updatedAt": "2026-08-20T06:32:52.735Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ossFrankFrank__dsh-dracula-theme/684d09a59a62e4180ac087918cb4f6d5aeffef9f/f5372d57bd76.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ossFrankFrank/dsh-dracula-theme/684d09a59a62e4180ac087918cb4f6d5aeffef9f/assets/preview.png"
+      "updatedAt": "2026-08-20T10:00:44.262Z"
     },
     {
       "id": "snowinkk.dsh-web-skin",
@@ -10606,9 +9941,9 @@
       "featuredRank": 191,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18 15:46:10.855000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:29:56.732Z",
+      "metadataUpdatedAt": "2026-08-20T10:01:04.697Z",
       "starsUpdatedAt": "2026-08-18 15:46:10.855000+00:00",
-      "updatedAt": "2026-08-20T06:29:56.732Z"
+      "updatedAt": "2026-08-20T10:01:04.697Z"
     },
     {
       "id": "sweetcandy-gift.dsh-beige-theme",
@@ -10641,7 +9976,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SweetCandy-gift__dsh-beige-theme/7b10152f18a50ee8f49fd558eb1be0ba31a5f5df/888741e49c0b.png",
         "https://raw.githubusercontent.com/SweetCandy-gift/dsh-beige-theme/7b10152f18a50ee8f49fd558eb1be0ba31a5f5df/docs/preview.png"
       ],
       "review": {
@@ -10670,13 +10004,9 @@
       "featuredRank": 192,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18T15:46:14.024Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:35.246Z",
+      "metadataUpdatedAt": "2026-08-20T10:01:06.079Z",
       "starsUpdatedAt": "2026-08-18T15:46:14.024Z",
-      "updatedAt": "2026-08-20T06:32:35.246Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SweetCandy-gift__dsh-beige-theme/7b10152f18a50ee8f49fd558eb1be0ba31a5f5df/888741e49c0b.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/SweetCandy-gift/dsh-beige-theme/7b10152f18a50ee8f49fd558eb1be0ba31a5f5df/docs/preview.png"
+      "updatedAt": "2026-08-20T10:01:06.079Z"
     },
     {
       "id": "webkubor.dsh-bloom-theme",
@@ -10700,9 +10030,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:webkubor/dsh-bloom-theme#9fa79ccea3c95703e9d928c768e433e3b01eb448",
+        "target": "github:webkubor/dsh-bloom-theme#96e12f2384bd6708a2c25d2a13a30aae01a9d567",
         "version": "0.3.6",
-        "commit": "9fa79ccea3c95703e9d928c768e433e3b01eb448"
+        "commit": "96e12f2384bd6708a2c25d2a13a30aae01a9d567"
       },
       "compatibility": {
         "dsh": "unverified",
@@ -10711,14 +10041,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/0137ac5534cf.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/c24092eb6a72.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/7e520c2b3667.png",
         "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/bloom-banner.png",
         "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/ui-mist-dark.png",
         "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/ui-cinnabar-dark.png",
         "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/ui-petal-dark.png",
-        "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/ui-ripple-dark.png"
+        "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/ui-ripple-dark.png",
+        "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/ui-mist-light.png"
       ],
       "review": {
         "compatibility": "unverified",
@@ -10744,16 +10072,10 @@
       },
       "featuredRank": 193,
       "starsSnapshot": 1,
-      "releaseUpdatedAt": "2026-08-20T05:08:55.406Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:57.764Z",
+      "releaseUpdatedAt": "2026-08-20T09:59:12.443Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:12.443Z",
       "starsUpdatedAt": "2026-08-20T05:08:55.406Z",
-      "updatedAt": "2026-08-20T06:32:57.764Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/0137ac5534cf.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/c24092eb6a72.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/7e520c2b3667.png"
-      ],
-      "listScreenshot": "https://cdn.jsdelivr.net/gh/webkubor/picx-images-hosting@master/projects/dsh-bloom-theme/bloom-banner.png"
+      "updatedAt": "2026-08-20T09:59:12.443Z"
     },
     {
       "id": "xxxrickymorty-dev.dsh-rick",
@@ -10811,9 +10133,9 @@
       "featuredRank": 196,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-18 15:46:32.876000+00:00",
-      "metadataUpdatedAt": "2026-08-20T06:30:09.024Z",
+      "metadataUpdatedAt": "2026-08-20T10:01:18.213Z",
       "starsUpdatedAt": "2026-08-18 15:46:32.876000+00:00",
-      "updatedAt": "2026-08-20T06:30:09.024Z"
+      "updatedAt": "2026-08-20T10:01:18.213Z"
     },
     {
       "id": "ycqaq233.dsh-unknown-theme",
@@ -10850,9 +10172,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/051cd68ea7db.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/3c0aecc60a3f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/8d2e2bd8df43.png",
         "https://raw.githubusercontent.com/ycqaq233/dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/assets/浅色主页.png",
         "https://raw.githubusercontent.com/ycqaq233/dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/assets/深色主页.png",
         "https://raw.githubusercontent.com/ycqaq233/dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/assets/浅色对话.png",
@@ -10881,15 +10200,9 @@
       "featuredRank": 197,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-18T15:46:37.156Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:59.672Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:19.484Z",
       "starsUpdatedAt": "2026-08-20T06:28:16.467Z",
-      "updatedAt": "2026-08-20T06:32:59.672Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/051cd68ea7db.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/3c0aecc60a3f.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/8d2e2bd8df43.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/ycqaq233/dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/assets/浅色主页.png"
+      "updatedAt": "2026-08-20T09:59:19.484Z"
     },
     {
       "id": "yzke.dsh-icon-theme",
@@ -11142,8 +10455,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GGBond2424648901__deep-whale-day-night-theme/3f6c4f14716d1e500f585be0c0d3c139c7a8a90b/f692c12edae7.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GGBond2424648901__deep-whale-day-night-theme/3f6c4f14716d1e500f585be0c0d3c139c7a8a90b/bd73fe5e723a.webp",
         "https://raw.githubusercontent.com/GGBond2424648901/deep-whale-day-night-theme/70b23c60d6a6dd4e0a67a0d1d5b1a123e6e2d12e/preview/light.webp",
         "https://raw.githubusercontent.com/GGBond2424648901/deep-whale-day-night-theme/70b23c60d6a6dd4e0a67a0d1d5b1a123e6e2d12e/preview/dark.webp"
       ],
@@ -11172,14 +10483,9 @@
       "featuredRank": 202,
       "starsSnapshot": 95,
       "releaseUpdatedAt": "2026-08-20T05:05:47.516Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:24.485Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:32.182Z",
       "starsUpdatedAt": "2026-08-20T05:05:47.516Z",
-      "updatedAt": "2026-08-20T06:32:24.485Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GGBond2424648901__deep-whale-day-night-theme/3f6c4f14716d1e500f585be0c0d3c139c7a8a90b/f692c12edae7.webp",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GGBond2424648901__deep-whale-day-night-theme/3f6c4f14716d1e500f585be0c0d3c139c7a8a90b/bd73fe5e723a.webp"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/GGBond2424648901/deep-whale-day-night-theme/70b23c60d6a6dd4e0a67a0d1d5b1a123e6e2d12e/preview/light.webp"
+      "updatedAt": "2026-08-20T09:55:32.182Z"
     },
     {
       "id": "springbrand-lab.dsh-web-ui-all",
@@ -11279,8 +10585,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/StarryHui__dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/3126cea8babd.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/StarryHui__dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/7e7cf8591cb7.png",
         "https://raw.githubusercontent.com/StarryHui/dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/images/zhuyemian.png",
         "https://raw.githubusercontent.com/StarryHui/dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/images/shezhiyemian.png"
       ],
@@ -11309,14 +10613,9 @@
       "featuredRank": 204,
       "starsSnapshot": 5,
       "releaseUpdatedAt": "2026-08-19T04:35:31.190Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:34.851Z",
+      "metadataUpdatedAt": "2026-08-20T09:56:46.047Z",
       "starsUpdatedAt": "2026-08-20T05:06:51.892Z",
-      "updatedAt": "2026-08-20T06:32:34.851Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/StarryHui__dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/3126cea8babd.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/StarryHui__dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/7e7cf8591cb7.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/StarryHui/dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/images/zhuyemian.png"
+      "updatedAt": "2026-08-20T09:56:46.047Z"
     },
     {
       "id": "linhut.dsh-stock-terminal",
@@ -11416,14 +10715,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/21276de29683.gif",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/43ce628c5bb0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/228e3f914bf9.png",
         "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/docs/images/live_wallpaper_demo.gif",
         "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/docs/images/desktop_main_preview.png",
         "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/docs/images/desktop_modal_preview.png",
         "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/docs/images/settings_preview.png",
-        "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/ef83b8e14733fa51c0fb3ab516649761ff97e327/docs/images/live_wallpaper_demo.gif"
+        "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/ef83b8e14733fa51c0fb3ab516649761ff97e327/docs/images/live_wallpaper_demo.gif",
+        "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/ef83b8e14733fa51c0fb3ab516649761ff97e327/docs/images/desktop_main_preview.png",
+        "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/ef83b8e14733fa51c0fb3ab516649761ff97e327/docs/images/desktop_modal_preview.png",
+        "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/ef83b8e14733fa51c0fb3ab516649761ff97e327/docs/images/settings_preview.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -11450,15 +10749,9 @@
       "featuredRank": 206,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-20T05:07:47.140Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:32.747Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:15.319Z",
       "starsUpdatedAt": "2026-08-20T06:26:19.885Z",
-      "updatedAt": "2026-08-20T06:32:32.747Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/21276de29683.gif",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/43ce628c5bb0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/228e3f914bf9.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Rainpomelo/deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/docs/images/live_wallpaper_demo.gif"
+      "updatedAt": "2026-08-20T09:57:15.319Z"
     },
     {
       "id": "alexyin-tongji.dsh-ui-enhancer",
@@ -11482,9 +10775,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:AlexYin-Tongji/dsh-ui-enhancer#045ec1f007e277c8b87bac8dad3d3afe02b95156",
-        "version": "0.1.0",
-        "commit": "045ec1f007e277c8b87bac8dad3d3afe02b95156"
+        "target": "github:AlexYin-Tongji/dsh-ui-enhancer#85028ebd65f966a5094ccff8568433244c6fc290",
+        "version": "0.1.1",
+        "commit": "85028ebd65f966a5094ccff8568433244c6fc290"
       },
       "compatibility": {
         "dsh": "0.1.0-rc.6",
@@ -11520,10 +10813,10 @@
       },
       "featuredRank": 207,
       "starsSnapshot": 0,
-      "releaseUpdatedAt": "2026-08-19T04:38:53.745Z",
+      "releaseUpdatedAt": "2026-08-20T09:59:34.385Z",
       "metadataUpdatedAt": "2026-08-19T04:38:53.745Z",
       "starsUpdatedAt": "2026-08-19T04:38:53.745Z",
-      "updatedAt": "2026-08-19T04:38:53.745Z"
+      "updatedAt": "2026-08-20T09:59:34.385Z"
     },
     {
       "id": "feng78-boop.dsh-thirteen-bg",
@@ -11609,9 +10902,9 @@
         "dark"
       ],
       "install": {
-        "target": "github:lesliechowsh/dsh-weniger-theme#6b8470905c32c4af50c71258c99e550f0498096a",
-        "version": "0.1.3",
-        "commit": "6b8470905c32c4af50c71258c99e550f0498096a"
+        "target": "github:lesliechowsh/dsh-weniger-theme#b88ab91040ea396e9c8cff7f13317532711eb2e3",
+        "version": "0.1.4",
+        "commit": "b88ab91040ea396e9c8cff7f13317532711eb2e3"
       },
       "compatibility": {
         "dsh": "unverified",
@@ -11620,7 +10913,7 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lesliechowsh__dsh-weniger-theme/6b8470905c32c4af50c71258c99e550f0498096a/0bd7398d4d8a.png",
+        "https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/b88ab91040ea396e9c8cff7f13317532711eb2e3/docs/screenshot-hero.png",
         "https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/6b8470905c32c4af50c71258c99e550f0498096a/docs/screenshot-hero.png",
         "https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/f64905000fd727604fe366cd001640406372ea48/docs/screenshot-hero.png"
       ],
@@ -11647,15 +10940,11 @@
         "commercialUse": true
       },
       "featuredRank": 209,
-      "starsSnapshot": 1,
-      "releaseUpdatedAt": "2026-08-20T05:09:58.235Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:48.447Z",
-      "starsUpdatedAt": "2026-08-20T06:27:41.232Z",
-      "updatedAt": "2026-08-20T06:32:48.447Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lesliechowsh__dsh-weniger-theme/6b8470905c32c4af50c71258c99e550f0498096a/0bd7398d4d8a.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/6b8470905c32c4af50c71258c99e550f0498096a/docs/screenshot-hero.png"
+      "starsSnapshot": 2,
+      "releaseUpdatedAt": "2026-08-20T09:58:41.587Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:41.587Z",
+      "starsUpdatedAt": "2026-08-20T09:58:41.587Z",
+      "updatedAt": "2026-08-20T09:58:41.587Z"
     },
     {
       "id": "leyan0365.dsh-retro-mac",
@@ -11886,8 +11175,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/1beff69363da.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/76f0c437fee9.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/aurora/preview/dark.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/aurora/preview/light.png"
       ],
@@ -11917,14 +11204,9 @@
       "featuredRank": 969,
       "starsSnapshot": 32,
       "releaseUpdatedAt": "2026-08-19T11:43:01.210764Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:21.698Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:38.698Z",
       "starsUpdatedAt": "2026-08-20T05:05:53.698Z",
-      "updatedAt": "2026-08-20T06:32:21.698Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/1beff69363da.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/76f0c437fee9.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/aurora/preview/dark.png"
+      "updatedAt": "2026-08-20T09:55:38.698Z"
     },
     {
       "id": "captain1275.blue-fantasy",
@@ -11960,8 +11242,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/2db1d964ca8b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/100b14a00d65.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/blue-fantasy/preview/dark.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/blue-fantasy/preview/light.png"
       ],
@@ -11991,14 +11271,9 @@
       "featuredRank": 969,
       "starsSnapshot": 32,
       "releaseUpdatedAt": "2026-08-20T05:05:54.830Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:21.801Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:39.916Z",
       "starsUpdatedAt": "2026-08-20T05:05:54.830Z",
-      "updatedAt": "2026-08-20T06:32:21.801Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/2db1d964ca8b.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/100b14a00d65.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/blue-fantasy/preview/dark.png"
+      "updatedAt": "2026-08-20T09:55:39.916Z"
     },
     {
       "id": "captain1275.dragon-heir",
@@ -12033,8 +11308,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/2f9278f8198d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/d202a391aee6.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/dragon-heir/preview/dark.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/dragon-heir/preview/light.png"
       ],
@@ -12064,14 +11337,9 @@
       "featuredRank": 969,
       "starsSnapshot": 32,
       "releaseUpdatedAt": "2026-08-20T05:05:56.031Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:22.051Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:41.028Z",
       "starsUpdatedAt": "2026-08-20T05:05:56.031Z",
-      "updatedAt": "2026-08-20T06:32:22.051Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/2f9278f8198d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/d202a391aee6.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/dragon-heir/preview/dark.png"
+      "updatedAt": "2026-08-20T09:55:41.028Z"
     },
     {
       "id": "captain1275.miku",
@@ -12167,8 +11435,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/99827797621c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/04001a4694d2.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/minecraft/preview/dark.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/minecraft/preview/light.png"
       ],
@@ -12198,14 +11464,9 @@
       "featuredRank": 969,
       "starsSnapshot": 32,
       "releaseUpdatedAt": "2026-08-20T05:05:57.834Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:22.509Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:42.036Z",
       "starsUpdatedAt": "2026-08-20T05:05:57.834Z",
-      "updatedAt": "2026-08-20T06:32:22.509Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/99827797621c.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/04001a4694d2.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/minecraft/preview/dark.png"
+      "updatedAt": "2026-08-20T09:55:42.036Z"
     },
     {
       "id": "captain1275.whale-song",
@@ -12241,8 +11502,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/4bb6efd96420.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/b7b5733f209a.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/whale-song/preview/dark.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/whale-song/preview/light.png"
       ],
@@ -12272,14 +11531,9 @@
       "featuredRank": 969,
       "starsSnapshot": 32,
       "releaseUpdatedAt": "2026-08-20T05:05:58.850Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:22.887Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:43.070Z",
       "starsUpdatedAt": "2026-08-20T05:05:58.850Z",
-      "updatedAt": "2026-08-20T06:32:22.887Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/4bb6efd96420.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/b7b5733f209a.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/whale-song/preview/dark.png"
+      "updatedAt": "2026-08-20T09:55:43.070Z"
     },
     {
       "id": "captain1275.xp",
@@ -12314,8 +11568,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/26f856e19a03.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/fe6c40241a76.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/xp/preview/dark.png",
         "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/xp/preview/light.png"
       ],
@@ -12345,14 +11597,9 @@
       "featuredRank": 969,
       "starsSnapshot": 32,
       "releaseUpdatedAt": "2026-08-20T05:05:59.690Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:23.028Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:44.414Z",
       "starsUpdatedAt": "2026-08-20T05:05:59.690Z",
-      "updatedAt": "2026-08-20T06:32:23.028Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/26f856e19a03.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/fe6c40241a76.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/CAPTAIN1275/dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/packages/skins/xp/preview/dark.png"
+      "updatedAt": "2026-08-20T09:55:44.414Z"
     },
     {
       "id": "dsh-skin-family",
@@ -12387,14 +11634,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/99df02243338.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/5cb2a6a01e6d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/90ff7f144eb1.png",
         "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/preview-all.png",
         "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/glass-dark.png",
         "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/claude-dark.png",
         "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/matrix-dark.png",
-        "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/sakura-light.png"
+        "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/sakura-light.png",
+        "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/glass-light.png",
+        "https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/preview-all.png",
+        "https://raw.githubusercontent.com/smdk000/dsh-skin-family/4e90a84f140eff12aa38e7ff4a9c8f7b69771cab/docs/glass-dark.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -12422,15 +11669,9 @@
       "featuredRank": 999,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:10:31.316Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:53.830Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:07.327Z",
       "starsUpdatedAt": "2026-08-20T05:10:31.316Z",
-      "updatedAt": "2026-08-20T06:32:53.830Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/99df02243338.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/5cb2a6a01e6d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/90ff7f144eb1.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/smdk000/dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/docs/preview-all.png"
+      "updatedAt": "2026-08-20T09:59:07.327Z"
     },
     {
       "id": "wensincai.dsh-skin-rotator",
@@ -12511,10 +11752,10 @@
         "dark"
       ],
       "install": {
-        "target": "github:elysia395/dsh-wallpaper-engine#86ce2f776021dee409294f8c44fab918e4703aa7",
+        "target": "github:elysia395/dsh-wallpaper-engine#48194e0af4dcf0ceb3650abf5430b372691f3459",
         "version": "0.3.5",
-        "commit": "86ce2f776021dee409294f8c44fab918e4703aa7",
-        "allowBuild": "dsh-plugin-wallpaper-engine@https://codeload.github.com/elysia395/dsh-wallpaper-engine/tar.gz/86ce2f776021dee409294f8c44fab918e4703aa7"
+        "commit": "48194e0af4dcf0ceb3650abf5430b372691f3459",
+        "allowBuild": "dsh-plugin-wallpaper-engine@https://codeload.github.com/elysia395/dsh-wallpaper-engine/tar.gz/48194e0af4dcf0ceb3650abf5430b372691f3459"
       },
       "compatibility": {
         "dsh": ">=0.1.0-rc.6",
@@ -12523,13 +11764,14 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/0145a6252585.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/b4a7c565ebaa.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/3b8bc3a87e91.png",
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/showcase.png",
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/features.png",
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/wallpaper-library.png",
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/compact-wallpaper-library.png",
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/vinyl-record.gif",
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/liquid-glass-window.png",
         "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/showcase.png",
-        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/features.png",
-        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/wallpaper-library.png",
-        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/better-sidebar.png"
+        "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/features.png"
       ],
       "review": {
         "compatibility": "verified",
@@ -12552,17 +11794,11 @@
         "commercialUse": true
       },
       "featuredRank": 1001,
-      "starsSnapshot": 100,
-      "releaseUpdatedAt": "2026-08-20T05:05:48.756Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:43.769Z",
-      "starsUpdatedAt": "2026-08-20T06:24:44.815Z",
-      "updatedAt": "2026-08-20T06:32:43.769Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/0145a6252585.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/b4a7c565ebaa.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/3b8bc3a87e91.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/showcase.png"
+      "starsSnapshot": 103,
+      "releaseUpdatedAt": "2026-08-20T09:55:33.282Z",
+      "metadataUpdatedAt": "2026-08-20T09:55:33.282Z",
+      "starsUpdatedAt": "2026-08-20T09:55:33.282Z",
+      "updatedAt": "2026-08-20T09:55:33.282Z"
     },
     {
       "id": "zhang9628.qixi-plugin",
@@ -12597,8 +11833,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Zhang9628__qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/e1f1b751add6.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Zhang9628__qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/54a0d22ec96e.png",
         "https://raw.githubusercontent.com/Zhang9628/qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/assets/barrage.jpg",
         "https://raw.githubusercontent.com/Zhang9628/qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/assets/card.png"
       ],
@@ -12627,14 +11861,9 @@
       "featuredRank": 1002,
       "starsSnapshot": 4,
       "releaseUpdatedAt": "2026-08-20T05:07:02.223Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:38.686Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:01.634Z",
       "starsUpdatedAt": "2026-08-20T05:07:02.223Z",
-      "updatedAt": "2026-08-20T06:32:38.686Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Zhang9628__qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/e1f1b751add6.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Zhang9628__qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/54a0d22ec96e.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Zhang9628/qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/assets/barrage.jpg"
+      "updatedAt": "2026-08-20T09:57:01.634Z"
     },
     {
       "id": "yuuhann1999.dsh-bloub-mood",
@@ -12670,9 +11899,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/ab317308fc1a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/f7dfee03e0bb.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/4819e66f833c.png",
         "https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/docs/settings-v2-expressions.png",
         "https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/docs/settings-v2-full.png",
         "https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/docs/app-in-action.png"
@@ -12702,15 +11928,9 @@
       "featuredRank": 1003,
       "starsSnapshot": 3,
       "releaseUpdatedAt": "2026-08-20T05:07:19.126Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:37.493Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:20.822Z",
       "starsUpdatedAt": "2026-08-20T05:07:19.126Z",
-      "updatedAt": "2026-08-20T06:32:37.493Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/ab317308fc1a.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/f7dfee03e0bb.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/4819e66f833c.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/Yuuhann1999/dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/docs/settings-v2-expressions.png"
+      "updatedAt": "2026-08-20T09:57:20.822Z"
     },
     {
       "id": "rnlao.dsh-wallpaper",
@@ -12745,7 +11965,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RNlao__dsh-wallpaper/cfa4bce21d2d6ee4944656658052e5391a5c81a5/0cf4e4299b36.png",
         "https://repository-images.githubusercontent.com/1333486205/208d5ee9-1233-4bdb-a99c-f985e7ccd975"
       ],
       "review": {
@@ -12773,13 +11992,9 @@
       "featuredRank": 1004,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T05:07:48.948Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:32.029Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:52.295Z",
       "starsUpdatedAt": "2026-08-20T05:07:48.948Z",
-      "updatedAt": "2026-08-20T06:32:32.029Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RNlao__dsh-wallpaper/cfa4bce21d2d6ee4944656658052e5391a5c81a5/0cf4e4299b36.png"
-      ],
-      "listScreenshot": "https://repository-images.githubusercontent.com/1333486205/208d5ee9-1233-4bdb-a99c-f985e7ccd975"
+      "updatedAt": "2026-08-20T09:57:52.295Z"
     },
     {
       "id": "cjz-wr.background-plugin",
@@ -12814,9 +12029,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/1a50651bdde0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/5f8ca6fb9ced.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/02c4e07d7586.png",
         "https://raw.githubusercontent.com/cjz-wr/background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/image1.png",
         "https://raw.githubusercontent.com/cjz-wr/background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/image.png",
         "https://raw.githubusercontent.com/cjz-wr/background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/image2.png"
@@ -12846,15 +12058,9 @@
       "featuredRank": 1005,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:08:05.437Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:40.967Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:13.056Z",
       "starsUpdatedAt": "2026-08-20T05:08:05.437Z",
-      "updatedAt": "2026-08-20T06:32:40.967Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/1a50651bdde0.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/5f8ca6fb9ced.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/02c4e07d7586.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/cjz-wr/background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/image1.png"
+      "updatedAt": "2026-08-20T09:58:13.056Z"
     },
     {
       "id": "frankxxxxue.dsh-photo-skins",
@@ -12889,9 +12095,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/1de33e92d33d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/a19d9fcff1ec.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/36d83a9acb97.png",
         "https://raw.githubusercontent.com/frankxxxxue/dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/screenshots/Interface_1.png",
         "https://raw.githubusercontent.com/frankxxxxue/dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/screenshots/Plugin_Path.png",
         "https://raw.githubusercontent.com/frankxxxxue/dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/screenshots/Interface_chat.png",
@@ -12920,15 +12123,9 @@
       "featuredRank": 1006,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:08:12.341Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:44.061Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:22.603Z",
       "starsUpdatedAt": "2026-08-20T05:08:12.341Z",
-      "updatedAt": "2026-08-20T06:32:44.061Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/1de33e92d33d.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/a19d9fcff1ec.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/36d83a9acb97.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/frankxxxxue/dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/screenshots/Interface_1.png"
+      "updatedAt": "2026-08-20T09:58:22.603Z"
     },
     {
       "id": "sakuraaa667.dsh-wallpaper-engine",
@@ -12962,7 +12159,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakuraaa667__dsh-wallpaper-engine/fba60078781763d80bb5b84b8f907ef98e3a632b/daa963db9870.jpg",
         "https://raw.githubusercontent.com/sakuraaa667/dsh-wallpaper-engine/fba60078781763d80bb5b84b8f907ef98e3a632b/assets/screenshot.jpg"
       ],
       "review": {
@@ -12990,13 +12186,9 @@
       "featuredRank": 1007,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T05:08:48.396Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:53.362Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:04.073Z",
       "starsUpdatedAt": "2026-08-20T05:08:48.396Z",
-      "updatedAt": "2026-08-20T06:32:53.362Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakuraaa667__dsh-wallpaper-engine/fba60078781763d80bb5b84b8f907ef98e3a632b/daa963db9870.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/sakuraaa667/dsh-wallpaper-engine/fba60078781763d80bb5b84b8f907ef98e3a632b/assets/screenshot.jpg"
+      "updatedAt": "2026-08-20T09:59:04.073Z"
     },
     {
       "id": "superls-x.dsh-minecraft-theme",
@@ -13031,9 +12223,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/313f2e0d563e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/139a6fe85de3.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/8bb9fed5dab7.png",
         "https://raw.githubusercontent.com/SuperLS-X/dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/screenshots/theme.png",
         "https://raw.githubusercontent.com/SuperLS-X/dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/screenshots/texture.png",
         "https://raw.githubusercontent.com/SuperLS-X/dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/screenshots/music.png"
@@ -13062,17 +12251,11 @@
         "commercialUse": true
       },
       "featuredRank": 1008,
-      "starsSnapshot": 3,
+      "starsSnapshot": 4,
       "releaseUpdatedAt": "2026-08-20T05:08:52.643Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:35.037Z",
-      "starsUpdatedAt": "2026-08-20T06:26:20.773Z",
-      "updatedAt": "2026-08-20T06:32:35.037Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/313f2e0d563e.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/139a6fe85de3.png",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/8bb9fed5dab7.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/SuperLS-X/dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/screenshots/theme.png"
+      "metadataUpdatedAt": "2026-08-20T09:57:00.543Z",
+      "starsUpdatedAt": "2026-08-20T09:57:00.543Z",
+      "updatedAt": "2026-08-20T09:57:00.543Z"
     },
     {
       "id": "bblike.dsh-plugin-odette",
@@ -13106,7 +12289,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bblike__dsh-plugin-odette/e8014e7b32daa8b23b2847d75e05f16ee4263ae9/eaf2b0cc4910.png",
         "https://raw.githubusercontent.com/bblike/dsh-plugin-odette/e8014e7b32daa8b23b2847d75e05f16ee4263ae9/assets/preview.png"
       ],
       "review": {
@@ -13134,13 +12316,9 @@
       "featuredRank": 1009,
       "starsSnapshot": 1,
       "releaseUpdatedAt": "2026-08-20T05:09:16.854Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:39.351Z",
+      "metadataUpdatedAt": "2026-08-20T09:58:08.209Z",
       "starsUpdatedAt": "2026-08-20T06:27:10.218Z",
-      "updatedAt": "2026-08-20T06:32:39.351Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bblike__dsh-plugin-odette/e8014e7b32daa8b23b2847d75e05f16ee4263ae9/eaf2b0cc4910.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/bblike/dsh-plugin-odette/e8014e7b32daa8b23b2847d75e05f16ee4263ae9/assets/preview.png"
+      "updatedAt": "2026-08-20T09:58:08.209Z"
     },
     {
       "id": "chengwill45-bot.dsh-hacker-terminal-theme",
@@ -13176,7 +12354,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chengwill45-bot__dsh-hacker-terminal-theme/b49094d19ee5e48323431feeea2aaadce78ea26f/47530d42e035.png",
         "https://raw.githubusercontent.com/chengwill45-bot/dsh-hacker-terminal-theme/b49094d19ee5e48323431feeea2aaadce78ea26f/preview.png"
       ],
       "review": {
@@ -13204,13 +12381,9 @@
       "featuredRank": 1010,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-20T05:09:24.489Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:40.553Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:48.549Z",
       "starsUpdatedAt": "2026-08-20T05:09:24.489Z",
-      "updatedAt": "2026-08-20T06:32:40.553Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chengwill45-bot__dsh-hacker-terminal-theme/b49094d19ee5e48323431feeea2aaadce78ea26f/47530d42e035.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/chengwill45-bot/dsh-hacker-terminal-theme/b49094d19ee5e48323431feeea2aaadce78ea26f/preview.png"
+      "updatedAt": "2026-08-20T09:59:48.549Z"
     },
     {
       "id": "enernitylune.dsh-luvian-ui-wallpaper",
@@ -13245,8 +12418,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EnernityLune__dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/5f85eb72010b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EnernityLune__dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/9808e1f0e281.jpg",
         "https://raw.githubusercontent.com/EnernityLune/dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/docs/screenshots/home.jpg",
         "https://raw.githubusercontent.com/EnernityLune/dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/docs/screenshots/chat.jpg"
       ],
@@ -13275,14 +12446,9 @@
       "featuredRank": 1011,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-20T05:09:34.405Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:23.626Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:59.369Z",
       "starsUpdatedAt": "2026-08-20T05:09:34.405Z",
-      "updatedAt": "2026-08-20T06:32:23.626Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EnernityLune__dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/5f85eb72010b.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EnernityLune__dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/9808e1f0e281.jpg"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/EnernityLune/dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/docs/screenshots/home.jpg"
+      "updatedAt": "2026-08-20T09:59:59.369Z"
     },
     {
       "id": "goatbroai.web-background",
@@ -13316,7 +12482,6 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/goatbroai__web-background/7cd751575f590c509c9c7545dbfd48d983aa3640/cd5bc8509f7e.png",
         "https://raw.githubusercontent.com/goatbroai/web-background/7cd751575f590c509c9c7545dbfd48d983aa3640/cover1.png"
       ],
       "review": {
@@ -13344,13 +12509,9 @@
       "featuredRank": 1012,
       "starsSnapshot": 0,
       "releaseUpdatedAt": "2026-08-20T05:09:40.396Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:44.297Z",
+      "metadataUpdatedAt": "2026-08-20T10:00:06.214Z",
       "starsUpdatedAt": "2026-08-20T05:09:40.396Z",
-      "updatedAt": "2026-08-20T06:32:44.297Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/goatbroai__web-background/7cd751575f590c509c9c7545dbfd48d983aa3640/cd5bc8509f7e.png"
-      ],
-      "listScreenshot": "https://raw.githubusercontent.com/goatbroai/web-background/7cd751575f590c509c9c7545dbfd48d983aa3640/cover1.png"
+      "updatedAt": "2026-08-20T10:00:06.214Z"
     },
     {
       "id": "haoyueqin.deepseek-harness-background",
@@ -13387,14 +12548,12 @@
         ]
       },
       "screenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/330e6fc147eb.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/f1c00481dec3.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/0e94feedd9b6.jpg",
         "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/docs/images/home.jpg",
         "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/docs/images/conversation.jpg",
         "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/docs/images/settings.jpg",
         "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/c6be3dfd00ecaa8dff1026107651ba6c240107bd/docs/images/home.jpg",
-        "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/c6be3dfd00ecaa8dff1026107651ba6c240107bd/docs/images/conversation.jpg"
+        "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/c6be3dfd00ecaa8dff1026107651ba6c240107bd/docs/images/conversation.jpg",
+        "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/c6be3dfd00ecaa8dff1026107651ba6c240107bd/docs/images/settings.jpg"
       ],
       "review": {
         "compatibility": "verified",
@@ -13421,15 +12580,79 @@
       "featuredRank": 1013,
       "starsSnapshot": 2,
       "releaseUpdatedAt": "2026-08-20T06:26:49.245Z",
-      "metadataUpdatedAt": "2026-08-20T06:32:26.289Z",
+      "metadataUpdatedAt": "2026-08-20T09:57:44.629Z",
       "starsUpdatedAt": "2026-08-20T06:26:49.245Z",
-      "updatedAt": "2026-08-20T06:32:26.289Z",
-      "marketScreenshots": [
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/330e6fc147eb.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/f1c00481dec3.jpg",
-        "https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/0e94feedd9b6.jpg"
+      "updatedAt": "2026-08-20T09:57:44.629Z"
+    },
+    {
+      "id": "ylifeonlyonce.dsh-calendar",
+      "name": {
+        "zh": "dsh-calendar",
+        "en": "dsh-calendar"
+      },
+      "author": "YLifeOnlyOnce",
+      "description": "一眼看清 DeepSeek 在什么时间、做了什么、做了多久。 一个漂亮、跟随主题的 DeepSeek Harness 使用日程表 —— 每个项目与任务的执行时间，支持 日 / 7天 / 月 / 年 视图。",
+      "repo": "https://github.com/YLifeOnlyOnce/dsh-calendar",
+      "package": "dsh-usage-calendar",
+      "rowId": "calendar",
+      "category": "theme",
+      "tags": [
+        "retro",
+        "token-theme",
+        "light-dark"
       ],
-      "listScreenshot": "https://raw.githubusercontent.com/HaoyueQin/deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/docs/images/home.jpg"
+      "modes": [
+        "light",
+        "dark"
+      ],
+      "install": {
+        "target": "github:YLifeOnlyOnce/dsh-calendar#aeefcd8506901a50eca3b2973d87d216e2467919",
+        "version": "0.1.1",
+        "commit": "aeefcd8506901a50eca3b2973d87d216e2467919",
+        "allowBuild": "dsh-usage-calendar@https://codeload.github.com/YLifeOnlyOnce/dsh-calendar/tar.gz/aeefcd8506901a50eca3b2973d87d216e2467919"
+      },
+      "compatibility": {
+        "dsh": "0.1.0-rc.7",
+        "platform": [
+          "web"
+        ]
+      },
+      "screenshots": [
+        "https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/banner.png",
+        "https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-year.png",
+        "https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-month.png",
+        "https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-7days.png",
+        "https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-day.png",
+        "https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/card-7days.png"
+      ],
+      "review": {
+        "compatibility": "verified",
+        "preview": "verified",
+        "installation": "manual-only"
+      },
+      "health": {
+        "status": "improvements",
+        "checks": {
+          "readmeScreenshots": "pass",
+          "compatibility": "pass",
+          "installation": "improve",
+          "installCommand": "pass",
+          "topic": "pass"
+        },
+        "suggestions": [
+          "建议补全稳定的 package 名称、dsh.client Web 声明、row ID 和已构建客户端入口，以符合 dsh 插件要求并获得更顺畅的一键安装体验。"
+        ]
+      },
+      "license": {
+        "code": "MIT",
+        "commercialUse": true
+      },
+      "featuredRank": 1014,
+      "starsSnapshot": 1,
+      "releaseUpdatedAt": "2026-08-20T09:59:22.838Z",
+      "metadataUpdatedAt": "2026-08-20T09:59:22.838Z",
+      "starsUpdatedAt": "2026-08-20T09:59:22.838Z",
+      "updatedAt": "2026-08-20T09:59:22.838Z"
     }
   ]
 }

--- a/docs/recently-added.md
+++ b/docs/recently-added.md
@@ -292,7 +292,7 @@ Windows XP Luna 皮肤：蓝色渐变窗口、绿色开始按钮、银色任务�
 [EachSheep/dsh-valley-pixel-skin](https://github.com/EachSheep/dsh-valley-pixel-skin)：给 DSH Desktop 和 Web UI 用的田园像素皮肤。春日农场铺在背景里，侧栏改成木质面板，主要工作区使用羊皮纸色半透明表面；默认增加 7px 背景模糊，让景色能看见，正文仍然清楚。
 
 - 版本：`0.1.0`
-- 固定 commit：`f6f4f7b0adb3b52620ceb0b7ea419d80b969b588`
+- 固定 commit：`23e0460d221a09deeb9e7fd3f7bbb438bc441b4c`
 
 <!-- dsh-auto-entry:dac114514.dsh-theme-center -->
 ### 2026-08-20 · dsh-theme-center
@@ -324,7 +324,7 @@ Windows XP Luna 皮肤：蓝色渐变窗口、绿色开始按钮、银色任务�
 [cdxDNRF/wishadel-theme](https://github.com/cdxDNRF/wishadel-theme)：dsh主题维什戴尔风格
 
 - 版本：`0.6.0`
-- 固定 commit：`02cb6818155dc4816e4de5824a6d6d756b0ba87b`
+- 固定 commit：`e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c`
 
 <!-- dsh-auto-entry:baihejiangnan.dsh-custom-wallpaper -->
 ### 2026-08-20 · dsh-custom-wallpaper
@@ -334,6 +334,14 @@ Windows XP Luna 皮肤：蓝色渐变窗口、绿色开始按钮、银色任务�
 - 版本：`0.1.0`
 - 固定 commit：`73f1f4b46ab54a88829239c0e891db3dc6c003ba`
 
+<!-- dsh-auto-entry:alexyin-tongji.dsh-ui-enhancer -->
+### 2026-08-20 · dsh-ui-enhancer
+
+[AlexYin-Tongji/dsh-ui-enhancer](https://github.com/AlexYin-Tongji/dsh-ui-enhancer)：面向 DeepSeek Harness Web 的桌面体验增强插件。它保留官方 UI 的会话和槽位契约，在其上组合成熟社区能力，并补充统一的个性化和文件引用体验。
+
+- 版本：`0.1.1`
+- 固定 commit：`85028ebd65f966a5094ccff8568433244c6fc290`
+
 <!-- dsh-auto-entry:adaning.dsh-pixel-skin -->
 ### 2026-08-20 · dsh-pixel-skin
 
@@ -341,14 +349,6 @@ Windows XP Luna 皮肤：蓝色渐变窗口、绿色开始按钮、银色任务�
 
 - 版本：`0.1.0`
 - 固定 commit：`cd34110195a94ca785f32e9b45d2f6e4bc685b1a`
-
-<!-- dsh-auto-entry:1mlightyears.dsh-theme-synthwave -->
-### 2026-08-20 · dsh-theme-synthwave
-
-[1MLightyears/dsh-theme-synthwave](https://github.com/1MLightyears/dsh-theme-synthwave)：给 DSH（DeepSeek Harness）Web UI 用的合成波 / Synthwave 主题插件。
-
-- 版本：`0.1.0`
-- 固定 commit：`f418fcb15674638defd4a4793e5f530346a8c25e`
 <!-- DSH_SKIN_MARKET_AUTO_RECENT:END -->
 
 ## 2026-08-18 · dsh-endfield-ui

--- a/registry/skins/0nt-one__dsh-neo-skin.yml
+++ b/registry/skins/0nt-one__dsh-neo-skin.yml
@@ -47,10 +47,6 @@ license:
 featuredRank: 74
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:51:42.695Z
-metadataUpdatedAt: 2026-08-20T06:32:19.550Z
+metadataUpdatedAt: 2026-08-20T09:57:25.326Z
 starsUpdatedAt: 2026-08-18T15:42:05.475Z
-updatedAt: 2026-08-20T06:32:19.550Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/6edff6216e23.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/61370c151ab7.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/0nt-one__dsh-neo-skin/fe5ef0e671fab5ab8c8700013f3966eb9642455f/8308768fc836.png
+updatedAt: 2026-08-20T09:57:25.326Z

--- a/registry/skins/1MLightyears__dsh-theme-synthwave.yml
+++ b/registry/skins/1MLightyears__dsh-theme-synthwave.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 167
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:00.135Z
-metadataUpdatedAt: 2026-08-20T06:32:19.997Z
+metadataUpdatedAt: 2026-08-20T09:59:31.904Z
 starsUpdatedAt: 2026-08-18T15:44:00.135Z
-updatedAt: 2026-08-20T06:32:19.997Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/1MLightyears__dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/de3891172afb.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/1MLightyears__dsh-theme-synthwave/f418fcb15674638defd4a4793e5f530346a8c25e/ceac5d4e03e6.png
+updatedAt: 2026-08-20T09:59:31.904Z

--- a/registry/skins/54088lp__dsh-kafka-ui.yml
+++ b/registry/skins/54088lp__dsh-kafka-ui.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 168
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:44:02.099Z
-metadataUpdatedAt: 2026-08-20T06:32:20.347Z
+metadataUpdatedAt: 2026-08-20T09:58:02.945Z
 starsUpdatedAt: 2026-08-20T05:07:57.674Z
-updatedAt: 2026-08-20T06:32:20.347Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/54088lp__dsh-kafka-ui/3cc47b912634897a878b2d201980c01edc86a804/f255aef984c8.png
+updatedAt: 2026-08-20T09:58:02.945Z

--- a/registry/skins/ADAning__dsh-pixel-skin.yml
+++ b/registry/skins/ADAning__dsh-pixel-skin.yml
@@ -49,10 +49,6 @@ license:
 featuredRank: 98
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:03.968Z
-metadataUpdatedAt: 2026-08-20T06:32:20.643Z
+metadataUpdatedAt: 2026-08-20T09:59:33.353Z
 starsUpdatedAt: 2026-08-16T13:54:49.092Z
-updatedAt: 2026-08-20T06:32:20.643Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/a91be4aad975.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/e4fed3d6dc7f.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ADAning__dsh-pixel-skin/cd34110195a94ca785f32e9b45d2f6e4bc685b1a/9f11b9685c4d.png
+updatedAt: 2026-08-20T09:59:33.353Z

--- a/registry/skins/AKS1st__dsh-cyber-particle.yml
+++ b/registry/skins/AKS1st__dsh-cyber-particle.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 25
 starsSnapshot: 10
 releaseUpdatedAt: 2026-08-18T15:39:29.241Z
-metadataUpdatedAt: 2026-08-20T06:32:20.944Z
+metadataUpdatedAt: 2026-08-20T09:56:07.415Z
 starsUpdatedAt: 2026-08-20T05:06:17.976Z
-updatedAt: 2026-08-20T06:32:20.944Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/582dd9739f30.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/AKS1st__dsh-cyber-particle/e08111d59df009454d9de6b8384907f697e038f6/c2182e95ae81.png
+updatedAt: 2026-08-20T09:56:07.415Z

--- a/registry/skins/Aik358__dsh-anchored-monitor.yml
+++ b/registry/skins/Aik358__dsh-anchored-monitor.yml
@@ -42,10 +42,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 155
-starsSnapshot: 3
+starsSnapshot: 4
 releaseUpdatedAt: 2026-08-20T05:07:05.976Z
-metadataUpdatedAt: 2026-08-20T06:32:21.178Z
-starsUpdatedAt: 2026-08-20T05:07:05.976Z
-updatedAt: 2026-08-20T06:32:21.178Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Aik358__dsh-anchored-monitor/8cb863fa50c3d17dec2683a247b93f90deeb5a16/dbba1a8220b6.png
+metadataUpdatedAt: 2026-08-20T09:56:50.641Z
+starsUpdatedAt: 2026-08-20T09:56:50.641Z
+updatedAt: 2026-08-20T09:56:50.641Z

--- a/registry/skins/AlexYin-Tongji__dsh-ui-enhancer.yml
+++ b/registry/skins/AlexYin-Tongji__dsh-ui-enhancer.yml
@@ -16,9 +16,9 @@ modes:
   - light
   - dark
 install:
-  target: github:AlexYin-Tongji/dsh-ui-enhancer#045ec1f007e277c8b87bac8dad3d3afe02b95156
-  version: 0.1.0
-  commit: 045ec1f007e277c8b87bac8dad3d3afe02b95156
+  target: github:AlexYin-Tongji/dsh-ui-enhancer#85028ebd65f966a5094ccff8568433244c6fc290
+  version: 0.1.1
+  commit: 85028ebd65f966a5094ccff8568433244c6fc290
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
@@ -45,7 +45,7 @@ license:
   commercialUse: true
 featuredRank: 207
 starsSnapshot: 0
-releaseUpdatedAt: 2026-08-19T04:38:53.745Z
+releaseUpdatedAt: 2026-08-20T09:59:34.385Z
 metadataUpdatedAt: 2026-08-19T04:38:53.745Z
 starsUpdatedAt: 2026-08-19T04:38:53.745Z
-updatedAt: 2026-08-19T04:38:53.745Z
+updatedAt: 2026-08-20T09:59:34.385Z

--- a/registry/skins/Anionex__dsh-eye-care.yml
+++ b/registry/skins/Anionex__dsh-eye-care.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 57
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:49:43.768Z
-metadataUpdatedAt: 2026-08-20T06:32:21.275Z
+metadataUpdatedAt: 2026-08-20T09:57:30.823Z
 starsUpdatedAt: 2026-08-16T13:49:43.768Z
-updatedAt: 2026-08-20T06:32:21.275Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Anionex__dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/ca1f4ec70142.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Anionex__dsh-eye-care/4f87acff00135317134e61a580c86198dad907c2/38732e0f0e3c.png
+updatedAt: 2026-08-20T09:57:30.823Z

--- a/registry/skins/Ayase34__gal-view.yml
+++ b/registry/skins/Ayase34__gal-view.yml
@@ -43,10 +43,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 135
-starsSnapshot: 106
+starsSnapshot: 107
 releaseUpdatedAt: 2026-08-16T09:00:49+09:00
-metadataUpdatedAt: 2026-08-20T06:32:21.450Z
-starsUpdatedAt: 2026-08-20T05:05:45.706Z
-updatedAt: 2026-08-20T06:32:21.450Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ayase34__gal-view/d002fe0e7051c618a2665af3c653f9838cd6aa8a/6cb3d89f0dac.png
+metadataUpdatedAt: 2026-08-20T09:55:28.757Z
+starsUpdatedAt: 2026-08-20T09:55:28.757Z
+updatedAt: 2026-08-20T09:55:28.757Z

--- a/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--aurora.yml
+++ b/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--aurora.yml
@@ -50,9 +50,6 @@ license:
 featuredRank: 969
 starsSnapshot: 32
 releaseUpdatedAt: 2026-08-19T11:43:01.210764Z
-metadataUpdatedAt: 2026-08-20T06:32:21.698Z
+metadataUpdatedAt: 2026-08-20T09:55:38.698Z
 starsUpdatedAt: 2026-08-20T05:05:53.698Z
-updatedAt: 2026-08-20T06:32:21.698Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/1beff69363da.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/76f0c437fee9.png
+updatedAt: 2026-08-20T09:55:38.698Z

--- a/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--blue-fantasy.yml
+++ b/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--blue-fantasy.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 969
 starsSnapshot: 32
 releaseUpdatedAt: 2026-08-20T05:05:54.830Z
-metadataUpdatedAt: 2026-08-20T06:32:21.801Z
+metadataUpdatedAt: 2026-08-20T09:55:39.916Z
 starsUpdatedAt: 2026-08-20T05:05:54.830Z
-updatedAt: 2026-08-20T06:32:21.801Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/2db1d964ca8b.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/100b14a00d65.png
+updatedAt: 2026-08-20T09:55:39.916Z

--- a/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--dragon-heir.yml
+++ b/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--dragon-heir.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 969
 starsSnapshot: 32
 releaseUpdatedAt: 2026-08-20T05:05:56.031Z
-metadataUpdatedAt: 2026-08-20T06:32:22.051Z
+metadataUpdatedAt: 2026-08-20T09:55:41.028Z
 starsUpdatedAt: 2026-08-20T05:05:56.031Z
-updatedAt: 2026-08-20T06:32:22.051Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/2f9278f8198d.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/d202a391aee6.png
+updatedAt: 2026-08-20T09:55:41.028Z

--- a/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--minecraft.yml
+++ b/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--minecraft.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 969
 starsSnapshot: 32
 releaseUpdatedAt: 2026-08-20T05:05:57.834Z
-metadataUpdatedAt: 2026-08-20T06:32:22.509Z
+metadataUpdatedAt: 2026-08-20T09:55:42.036Z
 starsUpdatedAt: 2026-08-20T05:05:57.834Z
-updatedAt: 2026-08-20T06:32:22.509Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/99827797621c.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/04001a4694d2.png
+updatedAt: 2026-08-20T09:55:42.036Z

--- a/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--whale-song.yml
+++ b/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--whale-song.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 969
 starsSnapshot: 32
 releaseUpdatedAt: 2026-08-20T05:05:58.850Z
-metadataUpdatedAt: 2026-08-20T06:32:22.887Z
+metadataUpdatedAt: 2026-08-20T09:55:43.070Z
 starsUpdatedAt: 2026-08-20T05:05:58.850Z
-updatedAt: 2026-08-20T06:32:22.887Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/4bb6efd96420.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/b7b5733f209a.png
+updatedAt: 2026-08-20T09:55:43.070Z

--- a/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--xp.yml
+++ b/registry/skins/CAPTAIN1275__dsh-ui-web--packages--skins--xp.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 969
 starsSnapshot: 32
 releaseUpdatedAt: 2026-08-20T05:05:59.690Z
-metadataUpdatedAt: 2026-08-20T06:32:23.028Z
+metadataUpdatedAt: 2026-08-20T09:55:44.414Z
 starsUpdatedAt: 2026-08-20T05:05:59.690Z
-updatedAt: 2026-08-20T06:32:23.028Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/26f856e19a03.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/CAPTAIN1275__dsh-ui-web/4a275b080cb6ff1a1a7a91a77e08aad6ad1eab56/fe6c40241a76.png
+updatedAt: 2026-08-20T09:55:44.414Z

--- a/registry/skins/Carpon39038__dsh-image-theme.yml
+++ b/registry/skins/Carpon39038__dsh-image-theme.yml
@@ -45,6 +45,6 @@ license:
 featuredRank: 60
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16 13:50:02.941000+00:00
-metadataUpdatedAt: 2026-08-20T06:26:37.362Z
+metadataUpdatedAt: 2026-08-20T09:57:32.882Z
 starsUpdatedAt: 2026-08-16 13:50:02.941000+00:00
-updatedAt: 2026-08-20T06:26:37.362Z
+updatedAt: 2026-08-20T09:57:32.882Z

--- a/registry/skins/DocJlm__dsh-arknights--skins--pramanix-eyjafjalla.yml
+++ b/registry/skins/DocJlm__dsh-arknights--skins--pramanix-eyjafjalla.yml
@@ -48,8 +48,6 @@ license:
 featuredRank: 17
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T05:07:35.441Z
-metadataUpdatedAt: 2026-08-20T06:32:23.219Z
+metadataUpdatedAt: 2026-08-20T09:57:39.074Z
 starsUpdatedAt: 2026-08-18T15:41:31.928Z
-updatedAt: 2026-08-20T06:32:23.219Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/DocJlm__dsh-arknights/87116ed1536c61dbb287addd9e4830cf3e8e0f36/28f69a05a44e.webp
+updatedAt: 2026-08-20T09:57:39.074Z

--- a/registry/skins/EachSheep__dsh-valley-pixel-skin.yml
+++ b/registry/skins/EachSheep__dsh-valley-pixel-skin.yml
@@ -17,14 +17,15 @@ modes:
   - light
   - dark
 install:
-  target: github:EachSheep/dsh-valley-pixel-skin#f6f4f7b0adb3b52620ceb0b7ea419d80b969b588
+  target: github:EachSheep/dsh-valley-pixel-skin#23e0460d221a09deeb9e7fd3f7bbb438bc441b4c
   version: 0.1.0
-  commit: f6f4f7b0adb3b52620ceb0b7ea419d80b969b588
+  commit: 23e0460d221a09deeb9e7fd3f7bbb438bc441b4c
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/23e0460d221a09deeb9e7fd3f7bbb438bc441b4c/preview/valley-spring-main.png
   - https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/f6f4f7b0adb3b52620ceb0b7ea419d80b969b588/preview/valley-spring-main.png
   - https://raw.githubusercontent.com/EachSheep/dsh-valley-pixel-skin/e746c941ffba2dd11ead96b50bc8c2964e9fef8b/preview/valley-spring-main.png
 review:
@@ -45,9 +46,7 @@ license:
   commercialUse: true
 featuredRank: 175
 starsSnapshot: 0
-releaseUpdatedAt: 2026-08-20T05:09:33.514Z
-metadataUpdatedAt: 2026-08-20T06:32:23.418Z
+releaseUpdatedAt: 2026-08-20T09:59:58.277Z
+metadataUpdatedAt: 2026-08-20T09:59:58.277Z
 starsUpdatedAt: 2026-08-18T15:44:34.423Z
-updatedAt: 2026-08-20T06:32:23.418Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EachSheep__dsh-valley-pixel-skin/f6f4f7b0adb3b52620ceb0b7ea419d80b969b588/b7c51dd8c7b2.png
+updatedAt: 2026-08-20T09:59:58.277Z

--- a/registry/skins/EnernityLune__dsh-luvian-ui-wallpaper.yml
+++ b/registry/skins/EnernityLune__dsh-luvian-ui-wallpaper.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 1011
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-20T05:09:34.405Z
-metadataUpdatedAt: 2026-08-20T06:32:23.626Z
+metadataUpdatedAt: 2026-08-20T09:59:59.369Z
 starsUpdatedAt: 2026-08-20T05:09:34.405Z
-updatedAt: 2026-08-20T06:32:23.626Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EnernityLune__dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/5f85eb72010b.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/EnernityLune__dsh-luvian-ui-wallpaper/fac6911fcfc870dbab861fcd1c9005facf9c1fa0/9808e1f0e281.jpg
+updatedAt: 2026-08-20T09:59:59.369Z

--- a/registry/skins/Estellalee__dsh-outdoor-theme.yml
+++ b/registry/skins/Estellalee__dsh-outdoor-theme.yml
@@ -49,10 +49,6 @@ license:
 featuredRank: 49
 starsSnapshot: 4
 releaseUpdatedAt: 2026-08-16T13:48:50.122Z
-metadataUpdatedAt: 2026-08-20T06:32:24.150Z
+metadataUpdatedAt: 2026-08-20T09:56:56.192Z
 starsUpdatedAt: 2026-08-18T15:40:12.882Z
-updatedAt: 2026-08-20T06:32:24.150Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/75e7d091c15c.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/857540e8612a.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Estellalee__dsh-outdoor-theme/236e5426f9a833191dd57758caef1fcd076d51ad/f3f8f5da7110.png
+updatedAt: 2026-08-20T09:56:56.192Z

--- a/registry/skins/Ewnscat-ya__dsh-client-ui-skin-denia.yml
+++ b/registry/skins/Ewnscat-ya__dsh-client-ui-skin-denia.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 133
 starsSnapshot: 22
 releaseUpdatedAt: 2026-08-18T15:39:04.526Z
-metadataUpdatedAt: 2026-08-20T06:32:24.358Z
+metadataUpdatedAt: 2026-08-20T09:55:48.506Z
 starsUpdatedAt: 2026-08-20T05:06:02.269Z
-updatedAt: 2026-08-20T06:32:24.358Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ewnscat-ya__dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/364d884e256e.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Ewnscat-ya__dsh-client-ui-skin-denia/1b846939864137123203f1cc8db628e1331df62a/a5d4d4fa6e03.webp
+updatedAt: 2026-08-20T09:55:48.506Z

--- a/registry/skins/FeatherHunter__dsh-opencode-palette.yml
+++ b/registry/skins/FeatherHunter__dsh-opencode-palette.yml
@@ -17,9 +17,9 @@ modes:
   - light
   - dark
 install:
-  target: github:FeatherHunter/dsh-opencode-palette#5aeadca70606ceb38f94080694e0c9fe47d4b10f&path:package
+  target: github:FeatherHunter/dsh-opencode-palette#e7460a9651e19ea02a7e9bc789810ab8b2a1d5e0&path:package
   version: 1.6.4
-  commit: 5aeadca70606ceb38f94080694e0c9fe47d4b10f
+  commit: e7460a9651e19ea02a7e9bc789810ab8b2a1d5e0
 compatibility:
   dsh: unverified
   platform:
@@ -49,7 +49,7 @@ license:
   commercialUse: true
 featuredRank: 139
 starsSnapshot: 7
-releaseUpdatedAt: 2026-08-18T12:25:52+08:00
+releaseUpdatedAt: 2026-08-20T09:56:16.140Z
 metadataUpdatedAt: 2026-08-18T15:40:14.498Z
 starsUpdatedAt: 2026-08-20T05:06:31.308Z
-updatedAt: 2026-08-20T05:06:31.308Z
+updatedAt: 2026-08-20T09:56:16.140Z

--- a/registry/skins/GGBond2424648901__deep-whale-day-night-theme.yml
+++ b/registry/skins/GGBond2424648901__deep-whale-day-night-theme.yml
@@ -50,9 +50,6 @@ license:
 featuredRank: 202
 starsSnapshot: 95
 releaseUpdatedAt: 2026-08-20T05:05:47.516Z
-metadataUpdatedAt: 2026-08-20T06:32:24.485Z
+metadataUpdatedAt: 2026-08-20T09:55:32.182Z
 starsUpdatedAt: 2026-08-20T05:05:47.516Z
-updatedAt: 2026-08-20T06:32:24.485Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GGBond2424648901__deep-whale-day-night-theme/3f6c4f14716d1e500f585be0c0d3c139c7a8a90b/f692c12edae7.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GGBond2424648901__deep-whale-day-night-theme/3f6c4f14716d1e500f585be0c0d3c139c7a8a90b/bd73fe5e723a.webp
+updatedAt: 2026-08-20T09:55:32.182Z

--- a/registry/skins/GptsApp__dsh-stylevault.yml
+++ b/registry/skins/GptsApp__dsh-stylevault.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 105
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:47.231Z
-metadataUpdatedAt: 2026-08-20T06:32:24.890Z
+metadataUpdatedAt: 2026-08-20T10:00:08.371Z
 starsUpdatedAt: 2026-08-16T13:55:39.547Z
-updatedAt: 2026-08-20T06:32:24.890Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/d81c0eb9a2f2.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/4b9015a2c71c.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/GptsApp__dsh-stylevault/b627f3a40c86cee9016d3749368479c08b5443b9/d1684ef1637d.png
+updatedAt: 2026-08-20T10:00:08.371Z

--- a/registry/skins/H-table__dsh-bg-tool.yml
+++ b/registry/skins/H-table__dsh-bg-tool.yml
@@ -52,10 +52,6 @@ license:
 featuredRank: 177
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-20T05:09:43.612Z
-metadataUpdatedAt: 2026-08-20T06:32:25.879Z
+metadataUpdatedAt: 2026-08-20T10:00:09.824Z
 starsUpdatedAt: 2026-08-18T15:44:48.848Z
-updatedAt: 2026-08-20T06:32:25.879Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/0967c5e7c488.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/d9f029fd0d67.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/H-table__dsh-bg-tool/409445faed5f594e646228d5c28d659998cbb1d5/303653506893.png
+updatedAt: 2026-08-20T10:00:09.824Z

--- a/registry/skins/HaoyueQin__deepseek-harness-background.yml
+++ b/registry/skins/HaoyueQin__deepseek-harness-background.yml
@@ -52,10 +52,6 @@ license:
 featuredRank: 1013
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T06:26:49.245Z
-metadataUpdatedAt: 2026-08-20T06:32:26.289Z
+metadataUpdatedAt: 2026-08-20T09:57:44.629Z
 starsUpdatedAt: 2026-08-20T06:26:49.245Z
-updatedAt: 2026-08-20T06:32:26.289Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/330e6fc147eb.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/f1c00481dec3.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/HaoyueQin__deepseek-harness-background/eb010b42763fdbf7c913d0fadbe6dd5371b70982/0e94feedd9b6.jpg
+updatedAt: 2026-08-20T09:57:44.629Z

--- a/registry/skins/Jack-sun-learner__dsh-image-skin.yml
+++ b/registry/skins/Jack-sun-learner__dsh-image-skin.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 81
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:47.474Z
-metadataUpdatedAt: 2026-08-20T06:32:26.505Z
+metadataUpdatedAt: 2026-08-20T09:58:30.233Z
 starsUpdatedAt: 2026-08-16T13:52:36.792Z
-updatedAt: 2026-08-20T06:32:26.505Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jack-sun-learner__dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/5b734d6cb78a.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jack-sun-learner__dsh-image-skin/896de5d72b5c05d4c8a2263af3586a0b0b4b8cb9/43792119e648.png
+updatedAt: 2026-08-20T09:58:30.233Z

--- a/registry/skins/Jayliu2025-vip__dsh-fate-twin-contract.yml
+++ b/registry/skins/Jayliu2025-vip__dsh-fate-twin-contract.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 108
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:55:59.921Z
-metadataUpdatedAt: 2026-08-20T06:32:26.600Z
+metadataUpdatedAt: 2026-08-20T10:00:14.272Z
 starsUpdatedAt: 2026-08-16T13:55:59.921Z
-updatedAt: 2026-08-20T06:32:26.600Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jayliu2025-vip__dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/b3a99705b866.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Jayliu2025-vip__dsh-fate-twin-contract/2564a25d0bb7a5ba88414075d4c8aa8f4a95cc87/1357090fed63.webp
+updatedAt: 2026-08-20T10:00:14.272Z

--- a/registry/skins/LaplaceYoung__dsh-qq2006.yml
+++ b/registry/skins/LaplaceYoung__dsh-qq2006.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 40
 starsSnapshot: 19
 releaseUpdatedAt: 2026-08-16 13:47:05.463000+00:00
-metadataUpdatedAt: 2026-08-20T06:32:26.748Z
+metadataUpdatedAt: 2026-08-20T09:55:53.604Z
 starsUpdatedAt: 2026-08-20T06:25:04.252Z
-updatedAt: 2026-08-20T06:32:26.748Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LaplaceYoung__dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/f185d2fa7e19.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LaplaceYoung__dsh-qq2006/fa3493ceb748171728113aba1aaf606d733790a0/8d4ea88b905c.webp
+updatedAt: 2026-08-20T09:55:53.604Z

--- a/registry/skins/LeemanCheung__dsh-qq2007-skin.yml
+++ b/registry/skins/LeemanCheung__dsh-qq2007-skin.yml
@@ -50,10 +50,6 @@ license:
 featuredRank: 14
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16 12:33:52.774000+00:00
-metadataUpdatedAt: 2026-08-20T06:32:27.007Z
+metadataUpdatedAt: 2026-08-20T09:57:11.479Z
 starsUpdatedAt: 2026-08-18 15:40:44.117000+00:00
-updatedAt: 2026-08-20T06:32:27.007Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/294784d41473.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/c1e6cee62cac.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-qq2007-skin/e7c61af021dab1d387566a07d3528dc563e4f070/53fb03f1212e.webp
+updatedAt: 2026-08-20T09:57:11.479Z

--- a/registry/skins/LeemanCheung__dsh-whale-companion.yml
+++ b/registry/skins/LeemanCheung__dsh-whale-companion.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 110
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:59.892Z
-metadataUpdatedAt: 2026-08-20T06:32:27.118Z
+metadataUpdatedAt: 2026-08-20T09:58:40.534Z
 starsUpdatedAt: 2026-08-18T15:42:59.892Z
-updatedAt: 2026-08-20T06:32:27.118Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LeemanCheung__dsh-whale-companion/9fca0908e5a96412f2314c047c2a0bedcdd642b8/61f1015e6fa4.png
+updatedAt: 2026-08-20T09:58:40.534Z

--- a/registry/skins/Lhy723__dsh-neu-theme.yml
+++ b/registry/skins/Lhy723__dsh-neu-theme.yml
@@ -48,10 +48,6 @@ license:
 featuredRank: 11
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-18T15:40:45.859Z
-metadataUpdatedAt: 2026-08-20T06:32:27.417Z
+metadataUpdatedAt: 2026-08-20T09:57:12.547Z
 starsUpdatedAt: 2026-08-18T15:40:45.859Z
-updatedAt: 2026-08-20T06:32:27.417Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/554f879a86d7.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/e9ae543dbabe.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Lhy723__dsh-neu-theme/54f4a07c0364f9f9d571a1384471e3825e1c14a4/d45f12956808.webp
+updatedAt: 2026-08-20T09:57:12.547Z

--- a/registry/skins/LilycleHeart__liuli-theme.yml
+++ b/registry/skins/LilycleHeart__liuli-theme.yml
@@ -57,10 +57,6 @@ license:
 featuredRank: 64
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T05:07:44.182Z
-metadataUpdatedAt: 2026-08-20T06:32:29.265Z
+metadataUpdatedAt: 2026-08-20T09:57:45.623Z
 starsUpdatedAt: 2026-08-16T13:50:39.220Z
-updatedAt: 2026-08-20T06:32:29.265Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/03514f2ef469.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/b6b4f08e77f0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/LilycleHeart__liuli-theme/776d01d0fbcda91922af2ffda9f213ff400023b5/5e94bdbc56f4.png
+updatedAt: 2026-08-20T09:57:45.623Z

--- a/registry/skins/Liu-ZA-81__dsh-theme-firefly.yml
+++ b/registry/skins/Liu-ZA-81__dsh-theme-firefly.yml
@@ -50,10 +50,6 @@ license:
 featuredRank: 153
 starsSnapshot: 7
 releaseUpdatedAt: 2026-08-20T05:06:46.763Z
-metadataUpdatedAt: 2026-08-20T06:32:29.714Z
+metadataUpdatedAt: 2026-08-20T09:56:40.089Z
 starsUpdatedAt: 2026-08-20T06:25:47.963Z
-updatedAt: 2026-08-20T06:32:29.714Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/b83bcbb2a11b.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/fe0cc32c7745.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Liu-ZA-81__dsh-theme-firefly/7937bc94872955ea0c6eb8842fc7b388e629ed52/0e87cb8d22cc.jpg
+updatedAt: 2026-08-20T09:56:40.089Z

--- a/registry/skins/MangMax__dsh-themes.yml
+++ b/registry/skins/MangMax__dsh-themes.yml
@@ -46,8 +46,6 @@ license:
 featuredRank: 30
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:43:10.613Z
-metadataUpdatedAt: 2026-08-20T06:32:29.920Z
+metadataUpdatedAt: 2026-08-20T09:58:48.348Z
 starsUpdatedAt: 2026-08-16T12:16:26.193Z
-updatedAt: 2026-08-20T06:32:29.920Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/MangMax__dsh-themes/85fe103cc2792da5eec2d57b045509256a5206d1/2ccaab0f3f0f.png
+updatedAt: 2026-08-20T09:58:48.348Z

--- a/registry/skins/Misaki14987__dsh-theme-taffy.yml
+++ b/registry/skins/Misaki14987__dsh-theme-taffy.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 44
 starsSnapshot: 6
 releaseUpdatedAt: 2026-08-16T13:48:03.686Z
-metadataUpdatedAt: 2026-08-20T06:32:30.029Z
+metadataUpdatedAt: 2026-08-20T09:56:26.591Z
 starsUpdatedAt: 2026-08-18T15:39:47.552Z
-updatedAt: 2026-08-20T06:32:30.029Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Misaki14987__dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/43afff001929.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Misaki14987__dsh-theme-taffy/58761735d967c3cbf551a9bd7aa292bb13258853/618a875a5a33.png
+updatedAt: 2026-08-20T09:56:26.591Z

--- a/registry/skins/Morinissleeping__dsh-pnc-theme.yml
+++ b/registry/skins/Morinissleeping__dsh-pnc-theme.yml
@@ -46,8 +46,6 @@ license:
 featuredRank: 115
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:56:51.169Z
-metadataUpdatedAt: 2026-08-20T06:32:30.720Z
+metadataUpdatedAt: 2026-08-20T10:00:37.425Z
 starsUpdatedAt: 2026-08-16T13:56:51.169Z
-updatedAt: 2026-08-20T06:32:30.720Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Morinissleeping__dsh-pnc-theme/07e2e0ebfd2fce33ca9737cdfe42acd6cb512377/7c7249ba8880.png
+updatedAt: 2026-08-20T10:00:37.425Z

--- a/registry/skins/Nagi-ovo__dsh-ads.yml
+++ b/registry/skins/Nagi-ovo__dsh-ads.yml
@@ -47,12 +47,8 @@ license:
   code: BSD-3-Clause
   commercialUse: true
 featuredRank: 142
-starsSnapshot: 514
+starsSnapshot: 516
 releaseUpdatedAt: 2026-08-18T02:28:44+01:00
-metadataUpdatedAt: 2026-08-20T06:32:31.248Z
-starsUpdatedAt: 2026-08-20T05:05:39.098Z
-updatedAt: 2026-08-20T06:32:31.248Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/963b54637a53.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/1776480921bb.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Nagi-ovo__dsh-ads/3a2ba704bc383099c686d3288ff6e0d61fc391e5/df0d8c1e4e25.webp
+metadataUpdatedAt: 2026-08-20T09:55:22.655Z
+starsUpdatedAt: 2026-08-20T09:55:22.655Z
+updatedAt: 2026-08-20T09:55:22.655Z

--- a/registry/skins/NoNameLeGo__dsh-catppuccin.yml
+++ b/registry/skins/NoNameLeGo__dsh-catppuccin.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 5
 starsSnapshot: 14
 releaseUpdatedAt: 2026-08-18 15:39:36.526000+00:00
-metadataUpdatedAt: 2026-08-20T06:32:31.533Z
+metadataUpdatedAt: 2026-08-20T09:55:59.481Z
 starsUpdatedAt: 2026-08-20T05:06:13.084Z
-updatedAt: 2026-08-20T06:32:31.533Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/134c7ddc5ba9.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/17ee53ec01d5.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/NoNameLeGo__dsh-catppuccin/46134262e1804f00331554a00c080d311a94e539/8d642012c832.png
+updatedAt: 2026-08-20T09:55:59.481Z

--- a/registry/skins/PAKIKNOWLEDGE__dsh-client-ui-skin-claude.yml
+++ b/registry/skins/PAKIKNOWLEDGE__dsh-client-ui-skin-claude.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 23
 starsSnapshot: 7
 releaseUpdatedAt: 2026-08-20T05:06:27.719Z
-metadataUpdatedAt: 2026-08-20T06:32:31.870Z
+metadataUpdatedAt: 2026-08-20T09:56:19.522Z
 starsUpdatedAt: 2026-08-18T15:39:39.240Z
-updatedAt: 2026-08-20T06:32:31.870Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/PAKIKNOWLEDGE__dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/2f7a34186827.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/PAKIKNOWLEDGE__dsh-client-ui-skin-claude/4d8fe6cfbff245b44bb8e0effc296ad2b513c9c5/43ce9beb5849.png
+updatedAt: 2026-08-20T09:56:19.522Z

--- a/registry/skins/RNlao__dsh-wallpaper.yml
+++ b/registry/skins/RNlao__dsh-wallpaper.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 1004
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T05:07:48.948Z
-metadataUpdatedAt: 2026-08-20T06:32:32.029Z
+metadataUpdatedAt: 2026-08-20T09:57:52.295Z
 starsUpdatedAt: 2026-08-20T05:07:48.948Z
-updatedAt: 2026-08-20T06:32:32.029Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RNlao__dsh-wallpaper/cfa4bce21d2d6ee4944656658052e5391a5c81a5/0cf4e4299b36.png
+updatedAt: 2026-08-20T09:57:52.295Z

--- a/registry/skins/Rainpomelo__deepseek-harness-liquid-glass-theme.yml
+++ b/registry/skins/Rainpomelo__deepseek-harness-liquid-glass-theme.yml
@@ -52,10 +52,6 @@ license:
 featuredRank: 206
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-20T05:07:47.140Z
-metadataUpdatedAt: 2026-08-20T06:32:32.747Z
+metadataUpdatedAt: 2026-08-20T09:57:15.319Z
 starsUpdatedAt: 2026-08-20T06:26:19.885Z
-updatedAt: 2026-08-20T06:32:32.747Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/21276de29683.gif
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/43ce628c5bb0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Rainpomelo__deepseek-harness-liquid-glass-theme/0f7f8dfffdcd06e1b8f9d5e5361cd806de9c9912/228e3f914bf9.png
+updatedAt: 2026-08-20T09:57:15.319Z

--- a/registry/skins/ReLuckyLucy__dsh_Rhine_Lab_themo.yml
+++ b/registry/skins/ReLuckyLucy__dsh_Rhine_Lab_themo.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 118
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:48.008Z
-metadataUpdatedAt: 2026-08-20T06:32:32.898Z
+metadataUpdatedAt: 2026-08-20T10:00:51.090Z
 starsUpdatedAt: 2026-08-16T13:57:12.755Z
-updatedAt: 2026-08-20T06:32:32.898Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ReLuckyLucy__dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/79d3d96c7fa0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ReLuckyLucy__dsh_Rhine_Lab_themo/54c2f2611f6bc6e36a784cc33908ad29bccef2b7/db812f42bff6.png
+updatedAt: 2026-08-20T10:00:51.090Z

--- a/registry/skins/RealHacker__dsh-theme-colorizer.yml
+++ b/registry/skins/RealHacker__dsh-theme-colorizer.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 117
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-18T15:41:45.407Z
-metadataUpdatedAt: 2026-08-20T06:32:33.015Z
+metadataUpdatedAt: 2026-08-20T09:57:51.239Z
 starsUpdatedAt: 2026-08-18T15:41:45.407Z
-updatedAt: 2026-08-20T06:32:33.015Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RealHacker__dsh-theme-colorizer/7c4152c1956ff87d93d74f928f1cf3a9e60101ca/04fcf2a77b23.jpeg
+updatedAt: 2026-08-20T09:57:51.239Z

--- a/registry/skins/RevolutionLA__dsh-dream-skin.yml
+++ b/registry/skins/RevolutionLA__dsh-dream-skin.yml
@@ -46,11 +46,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 4
-starsSnapshot: 65
+starsSnapshot: 67
 releaseUpdatedAt: 2026-08-20T05:05:50.110Z
-metadataUpdatedAt: 2026-08-20T06:32:33.761Z
-starsUpdatedAt: 2026-08-20T05:05:50.110Z
-updatedAt: 2026-08-20T06:32:33.761Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RevolutionLA__dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/b3726f0b5e63.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/RevolutionLA__dsh-dream-skin/7334b77169cc3ffbfc7f052c7c883ae33b2f9446/e44e667f05fd.png
+metadataUpdatedAt: 2026-08-20T09:55:34.388Z
+starsUpdatedAt: 2026-08-20T09:55:34.388Z
+updatedAt: 2026-08-20T09:55:34.388Z

--- a/registry/skins/SamizuHM__dsh-client-ui-theme-xp.yml
+++ b/registry/skins/SamizuHM__dsh-client-ui-theme-xp.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 28
 starsSnapshot: 6
 releaseUpdatedAt: 2026-08-16T12:16:17.062Z
-metadataUpdatedAt: 2026-08-20T06:32:33.927Z
+metadataUpdatedAt: 2026-08-20T09:56:41.425Z
 starsUpdatedAt: 2026-08-20T05:06:47.767Z
-updatedAt: 2026-08-20T06:32:33.927Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SamizuHM__dsh-client-ui-theme-xp/3cc412f4e877c127dea2e5b6e3413e5ddc95ce97/e256c4e2c123.png
+updatedAt: 2026-08-20T09:56:41.425Z

--- a/registry/skins/SenryLee__dsh-frosted-window.yml
+++ b/registry/skins/SenryLee__dsh-frosted-window.yml
@@ -47,8 +47,6 @@ license:
 featuredRank: 31
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:43:32.583Z
-metadataUpdatedAt: 2026-08-20T06:32:34.049Z
+metadataUpdatedAt: 2026-08-20T09:59:05.199Z
 starsUpdatedAt: 2026-08-16T12:16:30.062Z
-updatedAt: 2026-08-20T06:32:34.049Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SenryLee__dsh-frosted-window/ccee61d02837d2e3e3160743c07c8627a40c3438/b6930f43faad.jpg
+updatedAt: 2026-08-20T09:59:05.199Z

--- a/registry/skins/Small-tailqwq__dsh-deep-whale--maid-atelier.yml
+++ b/registry/skins/Small-tailqwq__dsh-deep-whale--maid-atelier.yml
@@ -20,9 +20,9 @@ modes:
   - light
   - dark
 install:
-  target: github:Small-tailqwq/dsh-deep-whale#d0419da95e51b6300de6b1c8205ee40f7644ca23&path:maid-atelier
+  target: github:Small-tailqwq/dsh-deep-whale#0a3d03251d1e88a08de79e27fb884ed9200913ad&path:maid-atelier
   version: 0.0.1
-  commit: d0419da95e51b6300de6b1c8205ee40f7644ca23
+  commit: 0a3d03251d1e88a08de79e27fb884ed9200913ad
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
@@ -50,11 +50,8 @@ license:
   commercialUse: false
   notice: 仅限非商业使用；详情页必须保留原仓库 NOTICE 署名链。
 featuredRank: 2
-starsSnapshot: 1476
-releaseUpdatedAt: 2026-08-20T05:05:37.073Z
-metadataUpdatedAt: 2026-08-20T06:32:34.160Z
-starsUpdatedAt: 2026-08-20T06:24:30.665Z
-updatedAt: 2026-08-20T06:32:34.160Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Small-tailqwq__dsh-deep-whale/d0419da95e51b6300de6b1c8205ee40f7644ca23/23a6539529d1.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Small-tailqwq__dsh-deep-whale/d0419da95e51b6300de6b1c8205ee40f7644ca23/d65aadf3ef65.webp
+starsSnapshot: 1488
+releaseUpdatedAt: 2026-08-20T09:55:20.364Z
+metadataUpdatedAt: 2026-08-20T09:55:20.364Z
+starsUpdatedAt: 2026-08-20T09:55:20.364Z
+updatedAt: 2026-08-20T09:55:20.364Z

--- a/registry/skins/Small-tailqwq__dsh-deep-whale--orca-link.yml
+++ b/registry/skins/Small-tailqwq__dsh-deep-whale--orca-link.yml
@@ -19,20 +19,22 @@ modes:
   - light
   - dark
 install:
-  target: github:Small-tailqwq/dsh-deep-whale#3d904c8e04bbe0eafe148e74341d7c81dd94572e&path:orca-link
+  target: github:Small-tailqwq/dsh-deep-whale#0a3d03251d1e88a08de79e27fb884ed9200913ad&path:orca-link
   version: 0.0.1
-  commit: 3d904c8e04bbe0eafe148e74341d7c81dd94572e
+  commit: 0a3d03251d1e88a08de79e27fb884ed9200913ad
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/0a3d03251d1e88a08de79e27fb884ed9200913ad/orca-link/preview/light.png
+  - https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/0a3d03251d1e88a08de79e27fb884ed9200913ad/orca-link/preview/dark.png
   - https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/3d904c8e04bbe0eafe148e74341d7c81dd94572e/orca-link/preview/light.png
   - https://raw.githubusercontent.com/Small-tailqwq/dsh-deep-whale/3d904c8e04bbe0eafe148e74341d7c81dd94572e/orca-link/preview/dark.png
 review:
   compatibility: unverified
   preview: verified
-  installation: manual-only
+  installation: verified
 health:
   status: improvements
   checks:
@@ -42,15 +44,15 @@ health:
     installCommand: pass
     topic: pass
   suggestions:
-    - 建议在 orca-link/README.md 中嵌入至少一张固定版本的 DSH Web 实机运行截图，方便用户直接确认皮肤效果。
+    - 建议在 README 中加入至少一张仓库内的真实界面截图，并让图片路径随仓库一起版本化，方便用户预览和市场稳定展示。
     - 建议在 README 或 package.json 中明确声明支持的 DSH Web 版本范围（例如 0.1.0-rc.6 或兼容区间），方便用户在安装前确认环境。
 license:
   code: CC-BY-NC-SA-4.0
   commercialUse: false
   notice: 仅限非商业使用；详情页必须保留原仓库 NOTICE 署名链。
 featuredRank: 3
-starsSnapshot: 1448
-releaseUpdatedAt: 2026-08-19T13:39:10Z
-metadataUpdatedAt: 2026-08-19T15:02:45Z
-starsUpdatedAt: 2026-08-19T15:02:45Z
-updatedAt: 2026-08-19T15:02:45Z
+starsSnapshot: 1488
+releaseUpdatedAt: 2026-08-20T09:55:18.878Z
+metadataUpdatedAt: 2026-08-20T09:55:18.878Z
+starsUpdatedAt: 2026-08-20T09:55:18.878Z
+updatedAt: 2026-08-20T09:55:18.878Z

--- a/registry/skins/SoDaZilla-zzz__dsh-liquid-glass-balance-card.yml
+++ b/registry/skins/SoDaZilla-zzz__dsh-liquid-glass-balance-card.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 147
 starsSnapshot: 5
 releaseUpdatedAt: 2026-08-20T05:06:48.636Z
-metadataUpdatedAt: 2026-08-20T06:32:34.666Z
+metadataUpdatedAt: 2026-08-20T09:56:42.530Z
 starsUpdatedAt: 2026-08-18T15:40:22.365Z
-updatedAt: 2026-08-20T06:32:34.666Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SoDaZilla-zzz__dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/247431a435ee.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SoDaZilla-zzz__dsh-liquid-glass-balance-card/3fbca87bf6d68af66f1669c592bae1e6e6ab4463/41e2db6c103d.gif
+updatedAt: 2026-08-20T09:56:42.530Z

--- a/registry/skins/StarryHui__dsh-custom-background.yml
+++ b/registry/skins/StarryHui__dsh-custom-background.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 204
 starsSnapshot: 5
 releaseUpdatedAt: 2026-08-19T04:35:31.190Z
-metadataUpdatedAt: 2026-08-20T06:32:34.851Z
+metadataUpdatedAt: 2026-08-20T09:56:46.047Z
 starsUpdatedAt: 2026-08-20T05:06:51.892Z
-updatedAt: 2026-08-20T06:32:34.851Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/StarryHui__dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/3126cea8babd.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/StarryHui__dsh-custom-background/f20300f49ee95fef949c5d55e6a6bbd62c5d692d/7e7cf8591cb7.png
+updatedAt: 2026-08-20T09:56:46.047Z

--- a/registry/skins/SuperLS-X__dsh-minecraft-theme.yml
+++ b/registry/skins/SuperLS-X__dsh-minecraft-theme.yml
@@ -46,12 +46,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 1008
-starsSnapshot: 3
+starsSnapshot: 4
 releaseUpdatedAt: 2026-08-20T05:08:52.643Z
-metadataUpdatedAt: 2026-08-20T06:32:35.037Z
-starsUpdatedAt: 2026-08-20T06:26:20.773Z
-updatedAt: 2026-08-20T06:32:35.037Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/313f2e0d563e.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/139a6fe85de3.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SuperLS-X__dsh-minecraft-theme/4915a6a16b66e004142c5bde42db968c201e1beb/8bb9fed5dab7.png
+metadataUpdatedAt: 2026-08-20T09:57:00.543Z
+starsUpdatedAt: 2026-08-20T09:57:00.543Z
+updatedAt: 2026-08-20T09:57:00.543Z

--- a/registry/skins/SweetCandy-gift__dsh-beige-theme.yml
+++ b/registry/skins/SweetCandy-gift__dsh-beige-theme.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 192
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:14.024Z
-metadataUpdatedAt: 2026-08-20T06:32:35.246Z
+metadataUpdatedAt: 2026-08-20T10:01:06.079Z
 starsUpdatedAt: 2026-08-18T15:46:14.024Z
-updatedAt: 2026-08-20T06:32:35.246Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/SweetCandy-gift__dsh-beige-theme/7b10152f18a50ee8f49fd558eb1be0ba31a5f5df/888741e49c0b.png
+updatedAt: 2026-08-20T10:01:06.079Z

--- a/registry/skins/TQSY114514__dsh-ui-appearance.yml
+++ b/registry/skins/TQSY114514__dsh-ui-appearance.yml
@@ -16,15 +16,17 @@ modes:
   - light
   - dark
 install:
-  target: github:TQSY114514/dsh-ui-appearance#0b47a643cd531ac4115867da7bee98588683f42e
+  target: github:TQSY114514/dsh-ui-appearance#19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9
   version: 0.1.3
-  commit: 0b47a643cd531ac4115867da7bee98588683f42e
-  allowBuild: dsh-ui-appearance@https://codeload.github.com/TQSY114514/dsh-ui-appearance/tar.gz/0b47a643cd531ac4115867da7bee98588683f42e
+  commit: 19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9
+  allowBuild: dsh-ui-appearance@https://codeload.github.com/TQSY114514/dsh-ui-appearance/tar.gz/19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9/docs/screenshot-settings.png
+  - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/19f508b90ce86df7a9a1c7d167fd9d8cb639d4c9/docs/screenshot-wallpaper.png
   - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/docs/screenshot-settings.png
   - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/docs/screenshot-wallpaper.png
   - https://raw.githubusercontent.com/TQSY114514/dsh-ui-appearance/a10dd26d1b9d8360c962c4f098f242ad4b6d0a2c/docs/screenshot-settings.png
@@ -49,10 +51,7 @@ license:
   commercialUse: true
 featuredRank: 36
 starsSnapshot: 9
-releaseUpdatedAt: 2026-08-20T05:06:28.645Z
-metadataUpdatedAt: 2026-08-20T06:32:35.737Z
+releaseUpdatedAt: 2026-08-20T09:56:20.540Z
+metadataUpdatedAt: 2026-08-20T09:56:20.540Z
 starsUpdatedAt: 2026-08-20T06:25:29.500Z
-updatedAt: 2026-08-20T06:32:35.737Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/TQSY114514__dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/4acbf420f1a9.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/TQSY114514__dsh-ui-appearance/0b47a643cd531ac4115867da7bee98588683f42e/6beb1109ae17.png
+updatedAt: 2026-08-20T09:56:20.540Z

--- a/registry/skins/Vim0x3c__dsh-skin-appearance.yml
+++ b/registry/skins/Vim0x3c__dsh-skin-appearance.yml
@@ -54,10 +54,6 @@ license:
 featuredRank: 45
 starsSnapshot: 5
 releaseUpdatedAt: 2026-08-20T06:25:54.319Z
-metadataUpdatedAt: 2026-08-20T06:32:36.482Z
+metadataUpdatedAt: 2026-08-20T09:56:47.073Z
 starsUpdatedAt: 2026-08-16T13:48:16.554Z
-updatedAt: 2026-08-20T06:32:36.482Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/15b08e2328e9.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/b8d74e78f8a7.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Vim0x3c__dsh-skin-appearance/7a58ae76e83cf97c78c22b0b0d48f0f2a48f039d/538476f151b3.jpg
+updatedAt: 2026-08-20T09:56:47.073Z

--- a/registry/skins/WYH66666666__DSH-Transparent-UI-Plugin.yml
+++ b/registry/skins/WYH66666666__DSH-Transparent-UI-Plugin.yml
@@ -17,14 +17,18 @@ modes:
   - light
   - dark
 install:
-  target: github:WYH66666666/DSH-Transparent-UI-Plugin#fa0cb1fd172a1301297727334b08d8322ee57077
+  target: github:WYH66666666/DSH-Transparent-UI-Plugin#27ebacb504f43c31c29c4b700b54f902a26da978
   version: 1.3.0
-  commit: fa0cb1fd172a1301297727334b08d8322ee57077
+  commit: 27ebacb504f43c31c29c4b700b54f902a26da978
 compatibility:
   dsh: ^0.1.0-rc.5
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/1.png
+  - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/2.png
+  - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/3.png
+  - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/27ebacb504f43c31c29c4b700b54f902a26da978/assets/4.png
   - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/1.png
   - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/2.png
   - https://raw.githubusercontent.com/WYH66666666/DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/assets/3.png
@@ -46,12 +50,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 37
-starsSnapshot: 334
-releaseUpdatedAt: 2026-08-18T15:38:18.212Z
-metadataUpdatedAt: 2026-08-20T06:32:36.800Z
-starsUpdatedAt: 2026-08-20T05:05:40.058Z
-updatedAt: 2026-08-20T06:32:36.800Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/92e236a557ce.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/0914e4e4b4ff.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WYH66666666__DSH-Transparent-UI-Plugin/fa0cb1fd172a1301297727334b08d8322ee57077/8fdc55ae4a15.png
+starsSnapshot: 337
+releaseUpdatedAt: 2026-08-20T09:55:23.785Z
+metadataUpdatedAt: 2026-08-20T09:55:23.785Z
+starsUpdatedAt: 2026-08-20T09:55:23.785Z
+updatedAt: 2026-08-20T09:55:23.785Z

--- a/registry/skins/WuWL-98__dsh-theme-paper.yml
+++ b/registry/skins/WuWL-98__dsh-theme-paper.yml
@@ -46,10 +46,6 @@ license:
 featuredRank: 125
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:58:11.377Z
-metadataUpdatedAt: 2026-08-20T06:32:37.303Z
+metadataUpdatedAt: 2026-08-20T09:59:13.858Z
 starsUpdatedAt: 2026-08-20T05:08:56.600Z
-updatedAt: 2026-08-20T06:32:37.303Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/9bee1198d94f.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/0c653a2510a4.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/WuWL-98__dsh-theme-paper/a13f7a3383543f14e1a50a58ee25865ea1185ed6/a2561f6c70a5.png
+updatedAt: 2026-08-20T09:59:13.858Z

--- a/registry/skins/X9wd09ncc__dsh-x9-theme.yml
+++ b/registry/skins/X9wd09ncc__dsh-x9-theme.yml
@@ -48,6 +48,6 @@ license:
 featuredRank: 96
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18 15:43:45.074000+00:00
-metadataUpdatedAt: 2026-08-20T06:28:15.265Z
+metadataUpdatedAt: 2026-08-20T09:59:18.208Z
 starsUpdatedAt: 2026-08-16 13:54:32.014000+00:00
-updatedAt: 2026-08-20T06:28:15.265Z
+updatedAt: 2026-08-20T09:59:18.208Z

--- a/registry/skins/YLifeOnlyOnce__dsh-calendar.yml
+++ b/registry/skins/YLifeOnlyOnce__dsh-calendar.yml
@@ -1,0 +1,56 @@
+id: ylifeonlyonce.dsh-calendar
+name:
+  zh: dsh-calendar
+  en: dsh-calendar
+author: YLifeOnlyOnce
+description: 一眼看清 DeepSeek 在什么时间、做了什么、做了多久。 一个漂亮、跟随主题的 DeepSeek Harness 使用日程表 —— 每个项目与任务的执行时间，支持 日 / 7天 / 月 / 年 视图。
+repo: https://github.com/YLifeOnlyOnce/dsh-calendar
+package: dsh-usage-calendar
+rowId: calendar
+category: theme
+tags:
+  - retro
+  - token-theme
+  - light-dark
+modes:
+  - light
+  - dark
+install:
+  target: github:YLifeOnlyOnce/dsh-calendar#aeefcd8506901a50eca3b2973d87d216e2467919
+  version: 0.1.1
+  commit: aeefcd8506901a50eca3b2973d87d216e2467919
+  allowBuild: dsh-usage-calendar@https://codeload.github.com/YLifeOnlyOnce/dsh-calendar/tar.gz/aeefcd8506901a50eca3b2973d87d216e2467919
+compatibility:
+  dsh: 0.1.0-rc.7
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/banner.png
+  - https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-year.png
+  - https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-month.png
+  - https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-7days.png
+  - https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/logs-day.png
+  - https://raw.githubusercontent.com/YLifeOnlyOnce/dsh-calendar/aeefcd8506901a50eca3b2973d87d216e2467919/docs/screenshots/card-7days.png
+review:
+  compatibility: verified
+  preview: verified
+  installation: manual-only
+health:
+  status: improvements
+  checks:
+    readmeScreenshots: pass
+    compatibility: pass
+    installation: improve
+    installCommand: pass
+    topic: pass
+  suggestions:
+    - 建议补全稳定的 package 名称、dsh.client Web 声明、row ID 和已构建客户端入口，以符合 dsh 插件要求并获得更顺畅的一键安装体验。
+license:
+  code: MIT
+  commercialUse: true
+featuredRank: 1014
+starsSnapshot: 1
+releaseUpdatedAt: 2026-08-20T09:59:22.838Z
+metadataUpdatedAt: 2026-08-20T09:59:22.838Z
+starsUpdatedAt: 2026-08-20T09:59:22.838Z
+updatedAt: 2026-08-20T09:59:22.838Z

--- a/registry/skins/Yuuhann1999__dsh-bloub-mood.yml
+++ b/registry/skins/Yuuhann1999__dsh-bloub-mood.yml
@@ -48,10 +48,6 @@ license:
 featuredRank: 1003
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-20T05:07:19.126Z
-metadataUpdatedAt: 2026-08-20T06:32:37.493Z
+metadataUpdatedAt: 2026-08-20T09:57:20.822Z
 starsUpdatedAt: 2026-08-20T05:07:19.126Z
-updatedAt: 2026-08-20T06:32:37.493Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/ab317308fc1a.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/f7dfee03e0bb.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Yuuhann1999__dsh-bloub-mood/19487c437a5557e9af75ac80e102f0093e485560/4819e66f833c.png
+updatedAt: 2026-08-20T09:57:20.822Z

--- a/registry/skins/ZJUZhiyuCai__dsh-ivory.yml
+++ b/registry/skins/ZJUZhiyuCai__dsh-ivory.yml
@@ -16,14 +16,18 @@ modes:
   - light
   - dark
 install:
-  target: github:ZJUZhiyuCai/dsh-ivory#3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317
-  version: 0.2.4
-  commit: 3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317
+  target: github:ZJUZhiyuCai/dsh-ivory#4cfd7236d4ef062946e54f43eb6d5a8f53407ab1
+  version: 0.2.5
+  commit: 4cfd7236d4ef062946e54f43eb6d5a8f53407ab1
 compatibility:
-  dsh: 0.1.0-rc.6
+  dsh: 0.1.0-rc.7
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/hero-light.png
+  - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/hero-dark.png
+  - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/conversation-light.png
+  - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/4cfd7236d4ef062946e54f43eb6d5a8f53407ab1/assets/mobile-light.png
   - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/hero-light.png
   - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/hero-dark.png
   - https://raw.githubusercontent.com/ZJUZhiyuCai/dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/assets/conversation-light.png
@@ -46,11 +50,7 @@ license:
   commercialUse: true
 featuredRank: 129
 starsSnapshot: 1
-releaseUpdatedAt: 2026-08-18T15:43:57.184Z
-metadataUpdatedAt: 2026-08-20T06:32:37.695Z
+releaseUpdatedAt: 2026-08-20T09:59:29.826Z
+metadataUpdatedAt: 2026-08-20T09:59:29.826Z
 starsUpdatedAt: 2026-08-18T15:43:57.184Z
-updatedAt: 2026-08-20T06:32:37.695Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/ecc3a4b73867.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/af7aee1db50b.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ZJUZhiyuCai__dsh-ivory/3391be192dfb3a5cc4b0ac7a6f43bfc7be03f317/8fac46f127fa.png
+updatedAt: 2026-08-20T09:59:29.826Z

--- a/registry/skins/Zhang9628__qixi-plugin.yml
+++ b/registry/skins/Zhang9628__qixi-plugin.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 1002
 starsSnapshot: 4
 releaseUpdatedAt: 2026-08-20T05:07:02.223Z
-metadataUpdatedAt: 2026-08-20T06:32:38.686Z
+metadataUpdatedAt: 2026-08-20T09:57:01.634Z
 starsUpdatedAt: 2026-08-20T05:07:02.223Z
-updatedAt: 2026-08-20T06:32:38.686Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Zhang9628__qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/e1f1b751add6.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/Zhang9628__qixi-plugin/581794ac36116e7d576d9270f1996b486bf6a8aa/54a0d22ec96e.png
+updatedAt: 2026-08-20T09:57:01.634Z

--- a/registry/skins/a1swg1159-pixel__dsh-arcaea-theme.yml
+++ b/registry/skins/a1swg1159-pixel__dsh-arcaea-theme.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 75
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:51:53.473Z
-metadataUpdatedAt: 2026-08-20T06:32:38.930Z
+metadataUpdatedAt: 2026-08-20T09:58:04.780Z
 starsUpdatedAt: 2026-08-16T13:51:53.473Z
-updatedAt: 2026-08-20T06:32:38.930Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/a1swg1159-pixel__dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/38be21aa596f.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/a1swg1159-pixel__dsh-arcaea-theme/7cbd4a03df2430ac39c32470cf0e4c7e93dc5918/0201bfda4059.png
+updatedAt: 2026-08-20T09:58:04.780Z

--- a/registry/skins/ai7603__dsh-cyberpunk-theme.yml
+++ b/registry/skins/ai7603__dsh-cyberpunk-theme.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 47
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16T13:48:35.219Z
-metadataUpdatedAt: 2026-08-20T06:32:39.099Z
+metadataUpdatedAt: 2026-08-20T09:57:04.724Z
 starsUpdatedAt: 2026-08-16T13:48:35.219Z
-updatedAt: 2026-08-20T06:32:39.099Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ai7603__dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/53a60b9880b0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ai7603__dsh-cyberpunk-theme/445693a248a03ebae53f155e8af0401410463d70/b990701c911a.png
+updatedAt: 2026-08-20T09:57:04.724Z

--- a/registry/skins/baihejiangnan__dsh-custom-wallpaper.yml
+++ b/registry/skins/baihejiangnan__dsh-custom-wallpaper.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 169
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:10.019Z
-metadataUpdatedAt: 2026-08-20T06:32:39.261Z
+metadataUpdatedAt: 2026-08-20T09:59:37.580Z
 starsUpdatedAt: 2026-08-18T15:44:10.019Z
-updatedAt: 2026-08-20T06:32:39.261Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/baihejiangnan__dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/7b14123994bc.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/baihejiangnan__dsh-custom-wallpaper/73f1f4b46ab54a88829239c0e891db3dc6c003ba/4656e215bac6.png
+updatedAt: 2026-08-20T09:59:37.580Z

--- a/registry/skins/bblike__dsh-plugin-odette.yml
+++ b/registry/skins/bblike__dsh-plugin-odette.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 1009
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:09:16.854Z
-metadataUpdatedAt: 2026-08-20T06:32:39.351Z
+metadataUpdatedAt: 2026-08-20T09:58:08.209Z
 starsUpdatedAt: 2026-08-20T06:27:10.218Z
-updatedAt: 2026-08-20T06:32:39.351Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bblike__dsh-plugin-odette/e8014e7b32daa8b23b2847d75e05f16ee4263ae9/eaf2b0cc4910.png
+updatedAt: 2026-08-20T09:58:08.209Z

--- a/registry/skins/bilbillm__deepseek-harness-angelina-themes.yml
+++ b/registry/skins/bilbillm__deepseek-harness-angelina-themes.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 58
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-18T15:40:34.001Z
-metadataUpdatedAt: 2026-08-20T06:32:39.780Z
+metadataUpdatedAt: 2026-08-20T09:57:07.073Z
 starsUpdatedAt: 2026-08-18T15:40:34.001Z
-updatedAt: 2026-08-20T06:32:39.780Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/052fe3ce7291.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/b0162272fb17.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/bilbillm__deepseek-harness-angelina-themes/ee74b2d6852173c0c1de39f6973685255de7229b/e58e9a8506c5.webp
+updatedAt: 2026-08-20T09:57:07.073Z

--- a/registry/skins/caoyiwei850__dsh-client-ui-skins.yml
+++ b/registry/skins/caoyiwei850__dsh-client-ui-skins.yml
@@ -46,10 +46,6 @@ license:
 featuredRank: 9
 starsSnapshot: 5
 releaseUpdatedAt: 2026-08-18T15:40:09.733Z
-metadataUpdatedAt: 2026-08-20T06:32:39.983Z
+metadataUpdatedAt: 2026-08-20T09:56:31.094Z
 starsUpdatedAt: 2026-08-18T15:40:09.733Z
-updatedAt: 2026-08-20T06:32:39.983Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/d14628fdfa63.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/129d4d9a631e.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/caoyiwei850__dsh-client-ui-skins/2d6d60b2f7c28312149db9507f2bd3ee8acadfdb/f16e9b920163.jpg
+updatedAt: 2026-08-20T09:56:31.094Z

--- a/registry/skins/cdxDNRF__wishadel-theme.yml
+++ b/registry/skins/cdxDNRF__wishadel-theme.yml
@@ -16,15 +16,17 @@ modes:
   - light
   - dark
 install:
-  target: github:cdxDNRF/wishadel-theme#02cb6818155dc4816e4de5824a6d6d756b0ba87b
+  target: github:cdxDNRF/wishadel-theme#e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c
   version: 0.6.0
-  commit: 02cb6818155dc4816e4de5824a6d6d756b0ba87b
-  allowBuild: "@cdxdnrf/dsh-client-ui-skin-wishadel@https://codeload.github.com/cdxDNRF/wishadel-theme/tar.gz/02cb6818155dc4816e4de5824a6d6d756b0ba87b"
+  commit: e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c
+  allowBuild: "@cdxdnrf/dsh-client-ui-skin-wishadel@https://codeload.github.com/cdxDNRF/wishadel-theme/tar.gz/e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c"
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c/docs/screenshots/conversation.png
+  - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/e0b2f2f49478d97bfe8eb84d8a1f3162c266b50c/docs/screenshots/settings.png
   - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/docs/screenshots/conversation.png
   - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/docs/screenshots/settings.png
   - https://raw.githubusercontent.com/cdxDNRF/wishadel-theme/ce8f1f11eb0ab29f9ed7e6ed277905a3d0390cf0/docs/screenshots/conversation.png
@@ -47,10 +49,7 @@ license:
   commercialUse: false
 featuredRank: 99
 starsSnapshot: 0
-releaseUpdatedAt: 2026-08-20T05:09:20.825Z
-metadataUpdatedAt: 2026-08-20T06:32:40.290Z
+releaseUpdatedAt: 2026-08-20T09:59:44.463Z
+metadataUpdatedAt: 2026-08-20T09:59:44.463Z
 starsUpdatedAt: 2026-08-16T13:54:53.805Z
-updatedAt: 2026-08-20T06:32:40.290Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cdxDNRF__wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/c3d7a856dc7d.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cdxDNRF__wishadel-theme/02cb6818155dc4816e4de5824a6d6d756b0ba87b/e9aed2b9941e.png
+updatedAt: 2026-08-20T09:59:44.463Z

--- a/registry/skins/charrywhite__dsh-sticky-notes.yml
+++ b/registry/skins/charrywhite__dsh-sticky-notes.yml
@@ -45,10 +45,6 @@ license:
 featuredRank: 146
 starsSnapshot: 5
 releaseUpdatedAt: 2026-08-18T15:39:58.583Z
-metadataUpdatedAt: 2026-08-20T06:32:40.537Z
+metadataUpdatedAt: 2026-08-20T09:56:32.185Z
 starsUpdatedAt: 2026-08-18T15:39:58.583Z
-updatedAt: 2026-08-20T06:32:40.537Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/8fe44a5facb0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/074f9ee979b1.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/charrywhite__dsh-sticky-notes/80a21d8acd76bf2d62f80f385864a0c01021c3b2/317e42125968.png
+updatedAt: 2026-08-20T09:56:32.185Z

--- a/registry/skins/chengwill45-bot__dsh-hacker-terminal-theme.yml
+++ b/registry/skins/chengwill45-bot__dsh-hacker-terminal-theme.yml
@@ -46,8 +46,6 @@ license:
 featuredRank: 1010
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-20T05:09:24.489Z
-metadataUpdatedAt: 2026-08-20T06:32:40.553Z
+metadataUpdatedAt: 2026-08-20T09:59:48.549Z
 starsUpdatedAt: 2026-08-20T05:09:24.489Z
-updatedAt: 2026-08-20T06:32:40.553Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chengwill45-bot__dsh-hacker-terminal-theme/b49094d19ee5e48323431feeea2aaadce78ea26f/47530d42e035.png
+updatedAt: 2026-08-20T09:59:48.549Z

--- a/registry/skins/chouxiaohuai__uiskin-theme.yml
+++ b/registry/skins/chouxiaohuai__uiskin-theme.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 159
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:08:04.519Z
-metadataUpdatedAt: 2026-08-20T06:32:40.669Z
+metadataUpdatedAt: 2026-08-20T09:58:11.892Z
 starsUpdatedAt: 2026-08-18T15:42:23.724Z
-updatedAt: 2026-08-20T06:32:40.669Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chouxiaohuai__uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/667a8d6a1eca.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/chouxiaohuai__uiskin-theme/50f6ee04073d7609ebaffaa563ebba3487c9a2d7/18ecf8a1a2fa.jpg
+updatedAt: 2026-08-20T09:58:11.892Z

--- a/registry/skins/cjz-wr__background-plugin.yml
+++ b/registry/skins/cjz-wr__background-plugin.yml
@@ -47,10 +47,6 @@ license:
 featuredRank: 1005
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:08:05.437Z
-metadataUpdatedAt: 2026-08-20T06:32:40.967Z
+metadataUpdatedAt: 2026-08-20T09:58:13.056Z
 starsUpdatedAt: 2026-08-20T05:08:05.437Z
-updatedAt: 2026-08-20T06:32:40.967Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/1a50651bdde0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/5f8ca6fb9ced.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/cjz-wr__background-plugin/1d3a6d063992cc74c60e03d65202d6615ab73ec4/02c4e07d7586.png
+updatedAt: 2026-08-20T09:58:13.056Z

--- a/registry/skins/crack-time__dsh-web-ui-skin.yml
+++ b/registry/skins/crack-time__dsh-web-ui-skin.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 174
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:25.553Z
-metadataUpdatedAt: 2026-08-20T06:32:41.091Z
+metadataUpdatedAt: 2026-08-20T09:59:52.898Z
 starsUpdatedAt: 2026-08-18T15:44:25.553Z
-updatedAt: 2026-08-20T06:32:41.091Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/crack-time__dsh-web-ui-skin/1300b594d16b292519a109385ad360247b6fba26/3af153abd2ca.jpg
+updatedAt: 2026-08-20T09:59:52.898Z

--- a/registry/skins/d-dev0101__open-sea-skin.yml
+++ b/registry/skins/d-dev0101__open-sea-skin.yml
@@ -54,10 +54,6 @@ license:
 featuredRank: 0
 starsSnapshot: 182
 releaseUpdatedAt: 2026-08-20T05:05:41.832Z
-metadataUpdatedAt: 2026-08-20T06:32:42.082Z
+metadataUpdatedAt: 2026-08-20T09:55:26.252Z
 starsUpdatedAt: 2026-08-20T05:05:41.832Z
-updatedAt: 2026-08-20T06:32:42.082Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/3d9689f0d936.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/ab2de3fe067a.gif
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/d-dev0101__open-sea-skin/2437d80a96de4124c54fbe89872fa7090103f025/0ca6e3276866.gif
+updatedAt: 2026-08-20T09:55:26.252Z

--- a/registry/skins/dac114514__dsh-theme-center.yml
+++ b/registry/skins/dac114514__dsh-theme-center.yml
@@ -47,10 +47,6 @@ license:
 featuredRank: 102
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:55:05.474Z
-metadataUpdatedAt: 2026-08-20T06:32:42.498Z
+metadataUpdatedAt: 2026-08-20T09:59:53.960Z
 starsUpdatedAt: 2026-08-16T13:55:05.474Z
-updatedAt: 2026-08-20T06:32:42.498Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/a7e2345aa86a.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/155ec3a25e26.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dac114514__dsh-theme-center/705b65215d3a5de0e600c48fc1800863c8d1c923/8d264d7da245.png
+updatedAt: 2026-08-20T09:59:53.960Z

--- a/registry/skins/dancingmemory__dskin.yml
+++ b/registry/skins/dancingmemory__dskin.yml
@@ -15,23 +15,23 @@ modes:
   - light
   - dark
 install:
-  target: github:dancingmemory/dskin#9ec8661b49bdf1a94250dcee9710cec22162a865
-  version: 1.0.15
-  commit: 9ec8661b49bdf1a94250dcee9710cec22162a865
-  allowBuild: dskin@https://codeload.github.com/dancingmemory/dskin/tar.gz/9ec8661b49bdf1a94250dcee9710cec22162a865
+  target: github:dancingmemory/dskin#792064e6dbb022c5f9ce3529b9cf66efba2863c1
+  version: 1.0.16
+  commit: 792064e6dbb022c5f9ce3529b9cf66efba2863c1
+  allowBuild: dskin@https://codeload.github.com/dancingmemory/dskin/tar.gz/792064e6dbb022c5f9ce3529b9cf66efba2863c1
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/banner.jpg
+  - https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-bigorange.png
+  - https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-white.png
+  - https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-black.png
+  - https://raw.githubusercontent.com/dancingmemory/dskin/792064e6dbb022c5f9ce3529b9cf66efba2863c1/assets/shot-tuxedo.png
   - https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/banner.jpg
   - https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-bigorange.png
   - https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-white.png
-  - https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-black.png
-  - https://raw.githubusercontent.com/dancingmemory/dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/assets/shot-tuxedo.png
-  - https://raw.githubusercontent.com/dancingmemory/dskin/acee0ab04c5257cce7f2045c8fe2f62926ee54a6/assets/banner.jpg
-  - https://raw.githubusercontent.com/dancingmemory/dskin/acee0ab04c5257cce7f2045c8fe2f62926ee54a6/assets/shot-bigorange.png
-  - https://raw.githubusercontent.com/dancingmemory/dskin/acee0ab04c5257cce7f2045c8fe2f62926ee54a6/assets/shot-white.png
 review:
   compatibility: unverified
   preview: verified
@@ -51,11 +51,7 @@ license:
   commercialUse: true
 featuredRank: 38
 starsSnapshot: 7
-releaseUpdatedAt: 2026-08-20T05:06:24.008Z
-metadataUpdatedAt: 2026-08-20T06:32:43.021Z
+releaseUpdatedAt: 2026-08-20T09:56:13.699Z
+metadataUpdatedAt: 2026-08-20T09:56:13.699Z
 starsUpdatedAt: 2026-08-18T15:39:30.818Z
-updatedAt: 2026-08-20T06:32:43.021Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/803075b9acef.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/b150c6915f94.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/dancingmemory__dskin/9ec8661b49bdf1a94250dcee9710cec22162a865/c62c291ee287.png
+updatedAt: 2026-08-20T09:56:13.699Z

--- a/registry/skins/drfccv__dsh-theme-neko.yml
+++ b/registry/skins/drfccv__dsh-theme-neko.yml
@@ -47,8 +47,6 @@ license:
 featuredRank: 46
 starsSnapshot: 4
 releaseUpdatedAt: 2026-08-18T15:40:11.189Z
-metadataUpdatedAt: 2026-08-20T06:32:43.197Z
+metadataUpdatedAt: 2026-08-20T09:56:55.033Z
 starsUpdatedAt: 2026-08-16T13:48:19.998Z
-updatedAt: 2026-08-20T06:32:43.197Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/drfccv__dsh-theme-neko/6c7c9a58ff93cef7117cbfc3b48a295039cd7c45/603f39169545.png
+updatedAt: 2026-08-20T09:56:55.033Z

--- a/registry/skins/elysia395__dsh-wallpaper-engine.yml
+++ b/registry/skins/elysia395__dsh-wallpaper-engine.yml
@@ -17,19 +17,23 @@ modes:
   - light
   - dark
 install:
-  target: github:elysia395/dsh-wallpaper-engine#86ce2f776021dee409294f8c44fab918e4703aa7
+  target: github:elysia395/dsh-wallpaper-engine#48194e0af4dcf0ceb3650abf5430b372691f3459
   version: 0.3.5
-  commit: 86ce2f776021dee409294f8c44fab918e4703aa7
-  allowBuild: dsh-plugin-wallpaper-engine@https://codeload.github.com/elysia395/dsh-wallpaper-engine/tar.gz/86ce2f776021dee409294f8c44fab918e4703aa7
+  commit: 48194e0af4dcf0ceb3650abf5430b372691f3459
+  allowBuild: dsh-plugin-wallpaper-engine@https://codeload.github.com/elysia395/dsh-wallpaper-engine/tar.gz/48194e0af4dcf0ceb3650abf5430b372691f3459
 compatibility:
   dsh: ">=0.1.0-rc.6"
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/showcase.png
+  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/features.png
+  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/wallpaper-library.png
+  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/compact-wallpaper-library.png
+  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/vinyl-record.gif
+  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/48194e0af4dcf0ceb3650abf5430b372691f3459/docs/images/liquid-glass-window.png
   - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/showcase.png
   - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/features.png
-  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/wallpaper-library.png
-  - https://raw.githubusercontent.com/elysia395/dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/docs/images/better-sidebar.png
 review:
   compatibility: verified
   preview: verified
@@ -47,12 +51,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 1001
-starsSnapshot: 100
-releaseUpdatedAt: 2026-08-20T05:05:48.756Z
-metadataUpdatedAt: 2026-08-20T06:32:43.769Z
-starsUpdatedAt: 2026-08-20T06:24:44.815Z
-updatedAt: 2026-08-20T06:32:43.769Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/0145a6252585.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/b4a7c565ebaa.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/elysia395__dsh-wallpaper-engine/86ce2f776021dee409294f8c44fab918e4703aa7/3b8bc3a87e91.png
+starsSnapshot: 103
+releaseUpdatedAt: 2026-08-20T09:55:33.282Z
+metadataUpdatedAt: 2026-08-20T09:55:33.282Z
+starsUpdatedAt: 2026-08-20T09:55:33.282Z
+updatedAt: 2026-08-20T09:55:33.282Z

--- a/registry/skins/frankxxxxue__dsh-photo-skins.yml
+++ b/registry/skins/frankxxxxue__dsh-photo-skins.yml
@@ -47,10 +47,6 @@ license:
 featuredRank: 1006
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:08:12.341Z
-metadataUpdatedAt: 2026-08-20T06:32:44.061Z
+metadataUpdatedAt: 2026-08-20T09:58:22.603Z
 starsUpdatedAt: 2026-08-20T05:08:12.341Z
-updatedAt: 2026-08-20T06:32:44.061Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/1de33e92d33d.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/a19d9fcff1ec.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/frankxxxxue__dsh-photo-skins/d90b3ce3dd25ab38131fa85ee77e969d296da622/36d83a9acb97.png
+updatedAt: 2026-08-20T09:58:22.603Z

--- a/registry/skins/goatbroai__web-background.yml
+++ b/registry/skins/goatbroai__web-background.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 1012
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-20T05:09:40.396Z
-metadataUpdatedAt: 2026-08-20T06:32:44.297Z
+metadataUpdatedAt: 2026-08-20T10:00:06.214Z
 starsUpdatedAt: 2026-08-20T05:09:40.396Z
-updatedAt: 2026-08-20T06:32:44.297Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/goatbroai__web-background/7cd751575f590c509c9c7545dbfd48d983aa3640/cd5bc8509f7e.png
+updatedAt: 2026-08-20T10:00:06.214Z

--- a/registry/skins/gooosie__dsh-whale-bg.yml
+++ b/registry/skins/gooosie__dsh-whale-bg.yml
@@ -48,8 +48,6 @@ license:
 featuredRank: 104
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:44:45.240Z
-metadataUpdatedAt: 2026-08-20T06:32:44.584Z
+metadataUpdatedAt: 2026-08-20T10:00:07.218Z
 starsUpdatedAt: 2026-08-16T13:55:34.455Z
-updatedAt: 2026-08-20T06:32:44.584Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/gooosie__dsh-whale-bg/2746a7eacba5c0dde28e29d00b6b15f1f2894164/3e89d80013f2.gif
+updatedAt: 2026-08-20T10:00:07.218Z

--- a/registry/skins/hachimi-ai__dsh-aemeath.yml
+++ b/registry/skins/hachimi-ai__dsh-aemeath.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 134
 starsSnapshot: 5
 releaseUpdatedAt: 2026-08-16T16:37:51Z
-metadataUpdatedAt: 2026-08-20T06:32:45.439Z
+metadataUpdatedAt: 2026-08-20T09:56:33.210Z
 starsUpdatedAt: 2026-08-20T05:07:43.055Z
-updatedAt: 2026-08-20T06:32:45.439Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hachimi-ai__dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/ff3e844f80c0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hachimi-ai__dsh-aemeath/f58eef75dcadb5aeaee9e78542e7e1d9ba43f821/e2808a184dc4.png
+updatedAt: 2026-08-20T09:56:33.210Z

--- a/registry/skins/hyposelen1a__dsh-columbina-theme.yml
+++ b/registry/skins/hyposelen1a__dsh-columbina-theme.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 160
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:08:15.274Z
-metadataUpdatedAt: 2026-08-20T06:32:46.102Z
+metadataUpdatedAt: 2026-08-20T09:58:25.769Z
 starsUpdatedAt: 2026-08-18T15:42:41.150Z
-updatedAt: 2026-08-20T06:32:46.102Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hyposelen1a__dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/7ea4a4807e4b.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/hyposelen1a__dsh-columbina-theme/2ccf33d427347f0dbf5004eb182f99182ee3c94e/6307251e7728.png
+updatedAt: 2026-08-20T09:58:25.769Z

--- a/registry/skins/i1j__dsh-krill-theme.yml
+++ b/registry/skins/i1j__dsh-krill-theme.yml
@@ -49,10 +49,6 @@ license:
 featuredRank: 79
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:52:26.766Z
-metadataUpdatedAt: 2026-08-20T06:32:46.283Z
+metadataUpdatedAt: 2026-08-20T09:58:26.765Z
 starsUpdatedAt: 2026-08-16T13:52:26.766Z
-updatedAt: 2026-08-20T06:32:46.283Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/4ccdfd92c330.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/06d1bf7daba1.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/i1j__dsh-krill-theme/8711e44fd5e9ae94c1913a2bda09be28162432d3/243fec45dadc.png
+updatedAt: 2026-08-20T09:58:26.765Z

--- a/registry/skins/ink5897__dsh-theme-kit.yml
+++ b/registry/skins/ink5897__dsh-theme-kit.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 80
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:52:31.430Z
-metadataUpdatedAt: 2026-08-20T06:32:46.587Z
+metadataUpdatedAt: 2026-08-20T09:58:28.988Z
 starsUpdatedAt: 2026-08-16T13:52:31.430Z
-updatedAt: 2026-08-20T06:32:46.587Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/1d9415a0803b.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/4286172cb1b0.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ink5897__dsh-theme-kit/0b2101b431491c24143f939daea8fd773ca2c641/e95b5aceb3e4.png
+updatedAt: 2026-08-20T09:58:28.988Z

--- a/registry/skins/jungeer__dsh-theme-stardew.yml
+++ b/registry/skins/jungeer__dsh-theme-stardew.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 161
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:49.178Z
-metadataUpdatedAt: 2026-08-20T06:32:46.818Z
+metadataUpdatedAt: 2026-08-20T09:58:31.321Z
 starsUpdatedAt: 2026-08-18T15:42:49.178Z
-updatedAt: 2026-08-20T06:32:46.818Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/jungeer__dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/db9d8ed579cf.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/jungeer__dsh-theme-stardew/2f2ac99cb821e4ebd8cd94a5e5cd6e9568c7863a/83d214c65f95.jpg
+updatedAt: 2026-08-20T09:58:31.321Z

--- a/registry/skins/justintangsysu__dsh-amadeus-skin.yml
+++ b/registry/skins/justintangsysu__dsh-amadeus-skin.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 181
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:09.310Z
-metadataUpdatedAt: 2026-08-20T06:32:46.924Z
+metadataUpdatedAt: 2026-08-20T10:00:21.114Z
 starsUpdatedAt: 2026-08-18T15:45:09.310Z
-updatedAt: 2026-08-20T06:32:46.924Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/justintangsysu__dsh-amadeus-skin/7f074e5d54b60fbfb423d11d096c5b054607c026/f53f07b39227.webp
+updatedAt: 2026-08-20T10:00:21.114Z

--- a/registry/skins/kingOfSoySauce__dsh-liang-skin.yml
+++ b/registry/skins/kingOfSoySauce__dsh-liang-skin.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 1
 starsSnapshot: 117
 releaseUpdatedAt: 2026-08-18T15:38:29.706Z
-metadataUpdatedAt: 2026-08-20T06:32:46.992Z
+metadataUpdatedAt: 2026-08-20T09:55:29.971Z
 starsUpdatedAt: 2026-08-20T06:24:41.264Z
-updatedAt: 2026-08-20T06:32:46.992Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/1e9bccbd1473.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-liang-skin/f65bf387a4a3e3f4680dd6bb63e7f30d20455543/8900c286f1ad.gif
+updatedAt: 2026-08-20T09:55:29.971Z

--- a/registry/skins/kingOfSoySauce__dsh-musk-skin.yml
+++ b/registry/skins/kingOfSoySauce__dsh-musk-skin.yml
@@ -49,10 +49,6 @@ license:
 featuredRank: 2
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:42:53.218Z
-metadataUpdatedAt: 2026-08-20T06:32:47.595Z
+metadataUpdatedAt: 2026-08-20T09:58:36.213Z
 starsUpdatedAt: 2026-08-18T09:15:01.000Z
-updatedAt: 2026-08-20T06:32:47.595Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/2dea7fdfb3b4.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/20808e0f2e29.gif
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/kingOfSoySauce__dsh-elon-skin/bccc746872cf8caa4005c9b144bcd1497717537a/1e9bccbd1473.png
+updatedAt: 2026-08-20T09:58:36.213Z

--- a/registry/skins/laoduu__DeepSeek-Harness-yizi-themes.yml
+++ b/registry/skins/laoduu__DeepSeek-Harness-yizi-themes.yml
@@ -50,8 +50,6 @@ license:
 featuredRank: 83
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:08:27.123Z
-metadataUpdatedAt: 2026-08-20T06:32:47.754Z
+metadataUpdatedAt: 2026-08-20T09:58:39.441Z
 starsUpdatedAt: 2026-08-16T13:52:49.212Z
-updatedAt: 2026-08-20T06:32:47.754Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/laoduu__DeepSeek-Harness-yizi-themes/377676424e0e45f919ab5e8ee54cb1ab0f96da73/1922bd780c28.png
+updatedAt: 2026-08-20T09:58:39.441Z

--- a/registry/skins/le-soleil-se-couche__dsh-skin-claude-code.yml
+++ b/registry/skins/le-soleil-se-couche__dsh-skin-claude-code.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 50
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-18T15:40:42.529Z
-metadataUpdatedAt: 2026-08-20T06:32:47.832Z
+metadataUpdatedAt: 2026-08-20T09:57:10.248Z
 starsUpdatedAt: 2026-08-16T13:49:00.442Z
-updatedAt: 2026-08-20T06:32:47.832Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/le-soleil-se-couche__dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/9a132e947166.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/le-soleil-se-couche__dsh-skin-claude-code/8590170e1c37eca3176469ade61998fd3d5088d4/80dec7d5302b.png
+updatedAt: 2026-08-20T09:57:10.248Z

--- a/registry/skins/lengduan__dsh-815-skin.yml
+++ b/registry/skins/lengduan__dsh-815-skin.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 111
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:14.378Z
-metadataUpdatedAt: 2026-08-20T06:32:48.285Z
+metadataUpdatedAt: 2026-08-20T10:00:25.139Z
 starsUpdatedAt: 2026-08-16T13:56:26.825Z
-updatedAt: 2026-08-20T06:32:48.285Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lengduan__dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/dcb8f6f6f38a.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lengduan__dsh-815-skin/5b0c843b8fb0e3e4a0a223209fb8768d3cd3275d/bc45aba2831b.png
+updatedAt: 2026-08-20T10:00:25.139Z

--- a/registry/skins/lesliechowsh__dsh-weniger-theme.yml
+++ b/registry/skins/lesliechowsh__dsh-weniger-theme.yml
@@ -16,14 +16,15 @@ modes:
   - light
   - dark
 install:
-  target: github:lesliechowsh/dsh-weniger-theme#6b8470905c32c4af50c71258c99e550f0498096a
-  version: 0.1.3
-  commit: 6b8470905c32c4af50c71258c99e550f0498096a
+  target: github:lesliechowsh/dsh-weniger-theme#b88ab91040ea396e9c8cff7f13317532711eb2e3
+  version: 0.1.4
+  commit: b88ab91040ea396e9c8cff7f13317532711eb2e3
 compatibility:
   dsh: unverified
   platform:
     - web
 screenshots:
+  - https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/b88ab91040ea396e9c8cff7f13317532711eb2e3/docs/screenshot-hero.png
   - https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/6b8470905c32c4af50c71258c99e550f0498096a/docs/screenshot-hero.png
   - https://raw.githubusercontent.com/lesliechowsh/dsh-weniger-theme/f64905000fd727604fe366cd001640406372ea48/docs/screenshot-hero.png
 review:
@@ -44,10 +45,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 209
-starsSnapshot: 1
-releaseUpdatedAt: 2026-08-20T05:09:58.235Z
-metadataUpdatedAt: 2026-08-20T06:32:48.447Z
-starsUpdatedAt: 2026-08-20T06:27:41.232Z
-updatedAt: 2026-08-20T06:32:48.447Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lesliechowsh__dsh-weniger-theme/6b8470905c32c4af50c71258c99e550f0498096a/0bd7398d4d8a.png
+starsSnapshot: 2
+releaseUpdatedAt: 2026-08-20T09:58:41.587Z
+metadataUpdatedAt: 2026-08-20T09:58:41.587Z
+starsUpdatedAt: 2026-08-20T09:58:41.587Z
+updatedAt: 2026-08-20T09:58:41.587Z

--- a/registry/skins/licheng-ma__dsh-wechat-skin.yml
+++ b/registry/skins/licheng-ma__dsh-wechat-skin.yml
@@ -43,8 +43,6 @@ license:
 featuredRank: 112
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:56:36.780Z
-metadataUpdatedAt: 2026-08-20T06:32:48.545Z
+metadataUpdatedAt: 2026-08-20T10:00:28.244Z
 starsUpdatedAt: 2026-08-16T13:56:36.780Z
-updatedAt: 2026-08-20T06:32:48.545Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/licheng-ma__dsh-wechat-skin/9528966105ab074631a9b3f7bdf8e2c0a13e3297/27cf701a2c6f.png
+updatedAt: 2026-08-20T10:00:28.244Z

--- a/registry/skins/linzhuoliSOC__dsh-skin-study.yml
+++ b/registry/skins/linzhuoliSOC__dsh-skin-study.yml
@@ -43,8 +43,6 @@ license:
 featuredRank: 113
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-20T05:10:02.178Z
-metadataUpdatedAt: 2026-08-20T06:32:48.743Z
+metadataUpdatedAt: 2026-08-20T10:00:29.598Z
 starsUpdatedAt: 2026-08-16T13:56:41.045Z
-updatedAt: 2026-08-20T06:32:48.743Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/linzhuoliSOC__dsh-skin-study/f37882361478ae9ac63f5d406e8f5e133df5590b/3055dfc69231.png
+updatedAt: 2026-08-20T10:00:29.598Z

--- a/registry/skins/lkdx0220__Genshin-odette-skin-dsh.yml
+++ b/registry/skins/lkdx0220__Genshin-odette-skin-dsh.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 182
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:23.237Z
-metadataUpdatedAt: 2026-08-20T06:32:48.958Z
+metadataUpdatedAt: 2026-08-20T10:00:31.506Z
 starsUpdatedAt: 2026-08-18T15:45:23.237Z
-updatedAt: 2026-08-20T06:32:48.958Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/87528228c92b.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/b1d4166746f7.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lkdx0220__Genshin-odette-skin-dsh/90ab5b724d956576973f3aca40b1b331aff7d42c/2514d0d2224c.jpg
+updatedAt: 2026-08-20T10:00:31.506Z

--- a/registry/skins/lssyd20070106__dsh-ui-preset-enhance.yml
+++ b/registry/skins/lssyd20070106__dsh-ui-preset-enhance.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 42
 starsSnapshot: 7
 releaseUpdatedAt: 2026-08-16T13:47:45.102Z
-metadataUpdatedAt: 2026-08-20T06:32:49.257Z
+metadataUpdatedAt: 2026-08-20T09:56:17.210Z
 starsUpdatedAt: 2026-08-18T15:39:35.097Z
-updatedAt: 2026-08-20T06:32:49.257Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lssyd20070106__dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/b7bc18eb093a.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lssyd20070106__dsh-ui-preset-enhance/36a18e24340677cf3c7a4771c861b9b931360e1e/6f50d463e0f0.png
+updatedAt: 2026-08-20T09:56:17.210Z

--- a/registry/skins/lyq3__dsh-skin-nebula.yml
+++ b/registry/skins/lyq3__dsh-skin-nebula.yml
@@ -52,10 +52,6 @@ license:
 featuredRank: 183
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:26.029Z
-metadataUpdatedAt: 2026-08-20T06:32:50.051Z
+metadataUpdatedAt: 2026-08-20T10:00:34.468Z
 starsUpdatedAt: 2026-08-18T15:45:26.029Z
-updatedAt: 2026-08-20T06:32:50.051Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/1792ec757772.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/107f44a4277e.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/lyq3__dsh-skin-nebula/57b9f7ff42faf9e71e038fb4f7c1826804eb47c7/79c78248e4cb.png
+updatedAt: 2026-08-20T10:00:34.468Z

--- a/registry/skins/makuralymi__dsh-webUI-Glass-Theme.yml
+++ b/registry/skins/makuralymi__dsh-webUI-Glass-Theme.yml
@@ -48,9 +48,6 @@ license:
 featuredRank: 53
 starsSnapshot: 4
 releaseUpdatedAt: 2026-08-20T05:07:01.312Z
-metadataUpdatedAt: 2026-08-20T06:32:50.545Z
+metadataUpdatedAt: 2026-08-20T09:56:59.474Z
 starsUpdatedAt: 2026-08-18T15:40:20.925Z
-updatedAt: 2026-08-20T06:32:50.545Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/makuralymi__dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/36757d3e0dad.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/makuralymi__dsh-webUI-Glass-Theme/c2be1d9d171c533da441d560dc3411344dfc6ea4/481e5e2eacbb.png
+updatedAt: 2026-08-20T09:56:59.474Z

--- a/registry/skins/mldhao__dsh-blue-archive-shiroko.yml
+++ b/registry/skins/mldhao__dsh-blue-archive-shiroko.yml
@@ -46,6 +46,6 @@ license:
 featuredRank: 86
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16 13:53:22.631000+00:00
-metadataUpdatedAt: 2026-08-20T06:27:50.749Z
+metadataUpdatedAt: 2026-08-20T09:58:51.780Z
 starsUpdatedAt: 2026-08-16 13:53:22.631000+00:00
-updatedAt: 2026-08-20T06:27:50.749Z
+updatedAt: 2026-08-20T09:58:51.780Z

--- a/registry/skins/mtaech__dsh-material-you.yml
+++ b/registry/skins/mtaech__dsh-material-you.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 87
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:28.039Z
-metadataUpdatedAt: 2026-08-20T06:32:50.873Z
+metadataUpdatedAt: 2026-08-20T09:58:52.911Z
 starsUpdatedAt: 2026-08-16T13:53:28.039Z
-updatedAt: 2026-08-20T06:32:50.873Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/mtaech__dsh-material-you/ed551a54dbf7f666e96b85f650cf01870117aba1/303831835f52.png
+updatedAt: 2026-08-20T09:58:52.911Z

--- a/registry/skins/niiang__dsh-kimino-theme.yml
+++ b/registry/skins/niiang__dsh-kimino-theme.yml
@@ -52,10 +52,6 @@ license:
 featuredRank: 145
 starsSnapshot: 17
 releaseUpdatedAt: 2026-08-20T05:06:18.924Z
-metadataUpdatedAt: 2026-08-20T06:32:52.236Z
+metadataUpdatedAt: 2026-08-20T09:56:08.852Z
 starsUpdatedAt: 2026-08-20T06:25:18.666Z
-updatedAt: 2026-08-20T06:32:52.236Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/a772df2ec4a5.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/39080628bbd4.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/niiang__dsh-kimino-theme/0a17159ecc9cf61834bac3265f5c8dab333431e9/98896630d591.png
+updatedAt: 2026-08-20T09:56:08.852Z

--- a/registry/skins/noexcs__dsh-skin-glass.yml
+++ b/registry/skins/noexcs__dsh-skin-glass.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 116
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:56:56.643Z
-metadataUpdatedAt: 2026-08-20T06:32:52.367Z
+metadataUpdatedAt: 2026-08-20T10:00:43.107Z
 starsUpdatedAt: 2026-08-16T13:56:56.643Z
-updatedAt: 2026-08-20T06:32:52.367Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/noexcs__dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/d7328cd03647.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/noexcs__dsh-skin-glass/085df7daf0ebc65f721e66896406bb9877489b59/ad584cd4addd.jpg
+updatedAt: 2026-08-20T10:00:43.107Z

--- a/registry/skins/oceanxuikun__dsh-eva-theme-plugin.yml
+++ b/registry/skins/oceanxuikun__dsh-eva-theme-plugin.yml
@@ -49,10 +49,6 @@ license:
 featuredRank: 89
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:35.278Z
-metadataUpdatedAt: 2026-08-20T06:32:52.714Z
+metadataUpdatedAt: 2026-08-20T09:58:58.271Z
 starsUpdatedAt: 2026-08-16T13:53:35.278Z
-updatedAt: 2026-08-20T06:32:52.714Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/b444d122740a.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/b325171f348c.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/oceanxuikun__dsh-eva-theme-plugin/dcdf404b83b0c49ccc16a9389222ec513ae3b81d/3030b9fbafe0.png
+updatedAt: 2026-08-20T09:58:58.271Z

--- a/registry/skins/ossFrankFrank__dsh-dracula-theme.yml
+++ b/registry/skins/ossFrankFrank__dsh-dracula-theme.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 186
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:45:38.721Z
-metadataUpdatedAt: 2026-08-20T06:32:52.735Z
+metadataUpdatedAt: 2026-08-20T10:00:44.262Z
 starsUpdatedAt: 2026-08-18T15:45:38.721Z
-updatedAt: 2026-08-20T06:32:52.735Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ossFrankFrank__dsh-dracula-theme/684d09a59a62e4180ac087918cb4f6d5aeffef9f/f5372d57bd76.png
+updatedAt: 2026-08-20T10:00:44.262Z

--- a/registry/skins/rison114514__dsh-endfield-ui.yml
+++ b/registry/skins/rison114514__dsh-endfield-ui.yml
@@ -50,11 +50,8 @@ license:
   commercialUse: true
   notice: 插件代码在 package.json 中声明为 MIT；仓库同时说明第三方字体、游戏视觉素材和品牌/角色素材的授权范围仍需逐项确认，因此市场不将整体素材视为可商业再分发。
 featuredRank: 143
-starsSnapshot: 20
+starsSnapshot: 22
 releaseUpdatedAt: 2026-08-20T05:06:20.536Z
-metadataUpdatedAt: 2026-08-20T06:32:53.063Z
-starsUpdatedAt: 2026-08-20T05:06:20.536Z
-updatedAt: 2026-08-20T06:32:53.063Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/2fd1a8fe59fc.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/rison114514__dsh-endfield-ui/ca61738988433a404a942d94f9e4a79500f0609c/914cfb5da9e1.jpg
+metadataUpdatedAt: 2026-08-20T09:55:51.419Z
+starsUpdatedAt: 2026-08-20T09:55:51.419Z
+updatedAt: 2026-08-20T09:55:51.419Z

--- a/registry/skins/sakka6868__dsh-skin.yml
+++ b/registry/skins/sakka6868__dsh-skin.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 92
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:53:50.782Z
-metadataUpdatedAt: 2026-08-20T06:32:53.277Z
+metadataUpdatedAt: 2026-08-20T09:57:53.404Z
 starsUpdatedAt: 2026-08-18T15:41:48.437Z
-updatedAt: 2026-08-20T06:32:53.277Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakka6868__dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/20b0b738be84.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakka6868__dsh-skin/802461800cfd20c640198c82df4d23a2c996c1bc/d49a2d9a6ec1.png
+updatedAt: 2026-08-20T09:57:53.404Z

--- a/registry/skins/sakuraaa667__dsh-wallpaper-engine.yml
+++ b/registry/skins/sakuraaa667__dsh-wallpaper-engine.yml
@@ -44,8 +44,6 @@ license:
 featuredRank: 1007
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T05:08:48.396Z
-metadataUpdatedAt: 2026-08-20T06:32:53.362Z
+metadataUpdatedAt: 2026-08-20T09:59:04.073Z
 starsUpdatedAt: 2026-08-20T05:08:48.396Z
-updatedAt: 2026-08-20T06:32:53.362Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/sakuraaa667__dsh-wallpaper-engine/fba60078781763d80bb5b84b8f907ef98e3a632b/daa963db9870.jpg
+updatedAt: 2026-08-20T09:59:04.073Z

--- a/registry/skins/smdk000__dsh-skin-family.yml
+++ b/registry/skins/smdk000__dsh-skin-family.yml
@@ -53,10 +53,6 @@ license:
 featuredRank: 999
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-20T05:10:31.316Z
-metadataUpdatedAt: 2026-08-20T06:32:53.830Z
+metadataUpdatedAt: 2026-08-20T09:59:07.327Z
 starsUpdatedAt: 2026-08-20T05:10:31.316Z
-updatedAt: 2026-08-20T06:32:53.830Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/99df02243338.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/5cb2a6a01e6d.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/smdk000__dsh-skin-family/db485bbad5e6139a64834c03a37601bcc690236b/90ff7f144eb1.png
+updatedAt: 2026-08-20T09:59:07.327Z

--- a/registry/skins/starslittle__dsh-blue-whale.yml
+++ b/registry/skins/starslittle__dsh-blue-whale.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 6
 starsSnapshot: 6
 releaseUpdatedAt: 2026-08-18T15:39:51.782Z
-metadataUpdatedAt: 2026-08-20T06:32:53.923Z
+metadataUpdatedAt: 2026-08-20T09:56:27.639Z
 starsUpdatedAt: 2026-08-16T12:31:55.720Z
-updatedAt: 2026-08-20T06:32:53.923Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/starslittle__dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/78026f449395.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/starslittle__dsh-blue-whale/e18aa1e27e98df98c478b8d24076a94e64d43ed5/5c2dd96207af.png
+updatedAt: 2026-08-20T09:56:27.639Z

--- a/registry/skins/statem-li__dsh-reasoning-effort.yml
+++ b/registry/skins/statem-li__dsh-reasoning-effort.yml
@@ -43,6 +43,6 @@ license:
 featuredRank: 191
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18 15:46:10.855000+00:00
-metadataUpdatedAt: 2026-08-20T06:29:56.732Z
+metadataUpdatedAt: 2026-08-20T10:01:04.697Z
 starsUpdatedAt: 2026-08-18 15:46:10.855000+00:00
-updatedAt: 2026-08-20T06:29:56.732Z
+updatedAt: 2026-08-20T10:01:04.697Z

--- a/registry/skins/suzike__freestyle-dsh-theme.yml
+++ b/registry/skins/suzike__freestyle-dsh-theme.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 41
 starsSnapshot: 12
 releaseUpdatedAt: 2026-08-16T13:47:08.953Z
-metadataUpdatedAt: 2026-08-20T06:32:54.071Z
+metadataUpdatedAt: 2026-08-20T09:56:05.313Z
 starsUpdatedAt: 2026-08-18T15:39:16.749Z
-updatedAt: 2026-08-20T06:32:54.071Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/suzike__freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/860e85d3e154.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/suzike__freestyle-dsh-theme/cd9e9eb53ccbaded4cf6123919e24392daeda0d4/3453249b5f1b.png
+updatedAt: 2026-08-20T09:56:05.313Z

--- a/registry/skins/syOPV__dsh-theme-background-center.yml
+++ b/registry/skins/syOPV__dsh-theme-background-center.yml
@@ -45,8 +45,6 @@ license:
 featuredRank: 93
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T13:53:58.612Z
-metadataUpdatedAt: 2026-08-20T06:32:54.148Z
+metadataUpdatedAt: 2026-08-20T09:59:10.372Z
 starsUpdatedAt: 2026-08-16T13:53:58.612Z
-updatedAt: 2026-08-20T06:32:54.148Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/syOPV__dsh-theme-background-center/06ff231740697a3f3119be72f5f715677bbbee2c/fc5dbd10316d.jpg
+updatedAt: 2026-08-20T09:59:10.372Z

--- a/registry/skins/thjyy__dph-endfield-theme.yml
+++ b/registry/skins/thjyy__dph-endfield-theme.yml
@@ -53,10 +53,6 @@ license:
 featuredRank: 121
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T05:07:51.150Z
-metadataUpdatedAt: 2026-08-20T06:32:55.106Z
+metadataUpdatedAt: 2026-08-20T09:57:54.878Z
 starsUpdatedAt: 2026-08-20T05:07:51.150Z
-updatedAt: 2026-08-20T06:32:55.106Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/d6bcb993bdc9.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/cc49e1ef3ad3.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/thjyy__dph-endfield-theme/a7d7467ed14db2504ab860073800244e4521d177/911cc3436296.gif
+updatedAt: 2026-08-20T09:57:54.878Z

--- a/registry/skins/tpmoonchefryan__dsh-joi-channel-theme.yml
+++ b/registry/skins/tpmoonchefryan__dsh-joi-channel-theme.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 94
 starsSnapshot: 9
 releaseUpdatedAt: 2026-08-20T06:25:22.023Z
-metadataUpdatedAt: 2026-08-20T06:32:56.889Z
+metadataUpdatedAt: 2026-08-20T09:56:12.254Z
 starsUpdatedAt: 2026-08-20T06:25:22.023Z
-updatedAt: 2026-08-20T06:32:56.889Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/324d165d7825.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/68354ebf4857.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/tpmoonchefryan__dsh-joi-channel-theme/3c12a2706759104a94b51013d19bb3e9c3f2bef1/f8e95439cf42.png
+updatedAt: 2026-08-20T09:56:12.254Z

--- a/registry/skins/wangxilhy23__dsh-wx-skin.yml
+++ b/registry/skins/wangxilhy23__dsh-wx-skin.yml
@@ -47,8 +47,6 @@ license:
 featuredRank: 68
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-20T05:07:52.874Z
-metadataUpdatedAt: 2026-08-20T06:32:57.007Z
+metadataUpdatedAt: 2026-08-20T09:57:57.193Z
 starsUpdatedAt: 2026-08-16T13:51:09.489Z
-updatedAt: 2026-08-20T06:32:57.007Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wangxilhy23__dsh-wx-skin/5351f776e73331ed70f5b656c8373c83b7a559a9/6803c02ed466.png
+updatedAt: 2026-08-20T09:57:57.193Z

--- a/registry/skins/wanzhiwei5__dsh-skin-amis.yml
+++ b/registry/skins/wanzhiwei5__dsh-skin-amis.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 69
 starsSnapshot: 2
 releaseUpdatedAt: 2026-08-16T13:51:14.660Z
-metadataUpdatedAt: 2026-08-20T06:32:57.238Z
+metadataUpdatedAt: 2026-08-20T09:57:58.275Z
 starsUpdatedAt: 2026-08-16T13:51:14.660Z
-updatedAt: 2026-08-20T06:32:57.238Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wanzhiwei5__dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/d0e074a3f7c5.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/wanzhiwei5__dsh-skin-amis/74d91e4b994d9fb8513ee3df97c43d3280390e58/fd43823d52be.png
+updatedAt: 2026-08-20T09:57:58.275Z

--- a/registry/skins/webkubor__dsh-bloom-theme.yml
+++ b/registry/skins/webkubor__dsh-bloom-theme.yml
@@ -16,9 +16,9 @@ modes:
   - light
   - dark
 install:
-  target: github:webkubor/dsh-bloom-theme#9fa79ccea3c95703e9d928c768e433e3b01eb448
+  target: github:webkubor/dsh-bloom-theme#96e12f2384bd6708a2c25d2a13a30aae01a9d567
   version: 0.3.6
-  commit: 9fa79ccea3c95703e9d928c768e433e3b01eb448
+  commit: 96e12f2384bd6708a2c25d2a13a30aae01a9d567
 compatibility:
   dsh: unverified
   platform:
@@ -49,11 +49,7 @@ license:
   commercialUse: true
 featuredRank: 193
 starsSnapshot: 1
-releaseUpdatedAt: 2026-08-20T05:08:55.406Z
-metadataUpdatedAt: 2026-08-20T06:32:57.764Z
+releaseUpdatedAt: 2026-08-20T09:59:12.443Z
+metadataUpdatedAt: 2026-08-20T09:59:12.443Z
 starsUpdatedAt: 2026-08-20T05:08:55.406Z
-updatedAt: 2026-08-20T06:32:57.764Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/0137ac5534cf.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/c24092eb6a72.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/webkubor__dsh-bloom-theme/9fa79ccea3c95703e9d928c768e433e3b01eb448/7e520c2b3667.png
+updatedAt: 2026-08-20T09:59:12.443Z

--- a/registry/skins/xiake595__touhou-hakurei.yml
+++ b/registry/skins/xiake595__touhou-hakurei.yml
@@ -53,10 +53,6 @@ license:
 featuredRank: 39
 starsSnapshot: 17
 releaseUpdatedAt: 2026-08-16T13:47:01.836Z
-metadataUpdatedAt: 2026-08-20T06:32:58.264Z
+metadataUpdatedAt: 2026-08-20T09:55:58.320Z
 starsUpdatedAt: 2026-08-20T05:06:09.460Z
-updatedAt: 2026-08-20T06:32:58.264Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/19cde8d3107b.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/b728cc860011.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiake595__touhou-hakurei/dae71e3b063f2051c590abbabaa1462cf2cd54ea/8611ab5c06b3.webp
+updatedAt: 2026-08-20T09:55:58.320Z

--- a/registry/skins/xiaoyanzi191__dsh-premium-themes.yml
+++ b/registry/skins/xiaoyanzi191__dsh-premium-themes.yml
@@ -52,10 +52,6 @@ license:
 featuredRank: 126
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:30.744Z
-metadataUpdatedAt: 2026-08-20T06:32:59.022Z
+metadataUpdatedAt: 2026-08-20T10:01:17.120Z
 starsUpdatedAt: 2026-08-16T13:58:16.091Z
-updatedAt: 2026-08-20T06:32:59.022Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/9ebead527a1e.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/1cd9a934cc80.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xiaoyanzi191__dsh-premium-themes/7e485999e45711396ba08806a40c9bfe3c650103/3c5ad53464e6.png
+updatedAt: 2026-08-20T10:01:17.120Z

--- a/registry/skins/xingyingyuzhui__dsh-liquid-glass.yml
+++ b/registry/skins/xingyingyuzhui__dsh-liquid-glass.yml
@@ -48,10 +48,6 @@ license:
 featuredRank: 21
 starsSnapshot: 11
 releaseUpdatedAt: 2026-08-16T12:15:45.060Z
-metadataUpdatedAt: 2026-08-20T06:32:59.263Z
+metadataUpdatedAt: 2026-08-20T09:56:06.377Z
 starsUpdatedAt: 2026-08-18T15:39:21.792Z
-updatedAt: 2026-08-20T06:32:59.263Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/e4be5edfdd62.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/2cd0157329ee.jpg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/xingyingyuzhui__dsh-liquid-glass/573a81d66ddff86216a61ebee4c755ed49ae31de/ddd024f450c7.jpg
+updatedAt: 2026-08-20T09:56:06.377Z

--- a/registry/skins/xxxrickymorty-dev__dsh-rick.yml
+++ b/registry/skins/xxxrickymorty-dev__dsh-rick.yml
@@ -42,6 +42,6 @@ license:
 featuredRank: 196
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18 15:46:32.876000+00:00
-metadataUpdatedAt: 2026-08-20T06:30:09.024Z
+metadataUpdatedAt: 2026-08-20T10:01:18.213Z
 starsUpdatedAt: 2026-08-18 15:46:32.876000+00:00
-updatedAt: 2026-08-20T06:30:09.024Z
+updatedAt: 2026-08-20T10:01:18.213Z

--- a/registry/skins/ycqaq233__dsh-unknown-theme.yml
+++ b/registry/skins/ycqaq233__dsh-unknown-theme.yml
@@ -49,10 +49,6 @@ license:
 featuredRank: 197
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:46:37.156Z
-metadataUpdatedAt: 2026-08-20T06:32:59.672Z
+metadataUpdatedAt: 2026-08-20T09:59:19.484Z
 starsUpdatedAt: 2026-08-20T06:28:16.467Z
-updatedAt: 2026-08-20T06:32:59.672Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/051cd68ea7db.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/3c0aecc60a3f.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/ycqaq233__dsh-unknown-theme/02e296a52b0ee53d1230bda14eed15683e547f1d/8d2e2bd8df43.png
+updatedAt: 2026-08-20T09:59:19.484Z

--- a/registry/skins/ymh0000123__dsh-theme-endfield.yml
+++ b/registry/skins/ymh0000123__dsh-theme-endfield.yml
@@ -45,8 +45,8 @@ license:
   code: MIT
   commercialUse: true
 featuredRank: 154
-starsSnapshot: 6
+starsSnapshot: 7
 releaseUpdatedAt: 2026-08-18 15:42:02.669000+00:00
 metadataUpdatedAt: 2026-08-18 15:42:02.669000+00:00
-starsUpdatedAt: 2026-08-20T05:06:36.282Z
-updatedAt: 2026-08-20T05:06:36.282Z
+starsUpdatedAt: 2026-08-20T09:56:21.746Z
+updatedAt: 2026-08-20T09:56:21.746Z

--- a/registry/skins/youyli03__dsh-palenight-theme.yml
+++ b/registry/skins/youyli03__dsh-palenight-theme.yml
@@ -46,9 +46,6 @@ license:
 featuredRank: 127
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-16T13:58:24.026Z
-metadataUpdatedAt: 2026-08-20T06:32:59.893Z
+metadataUpdatedAt: 2026-08-20T10:01:25.222Z
 starsUpdatedAt: 2026-08-16T13:58:24.026Z
-updatedAt: 2026-08-20T06:32:59.893Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/youyli03__dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/5398cd56b6a8.jpeg
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/youyli03__dsh-palenight-theme/94d2f61a679c6760c58357f5a0f2bee7c9bca906/467c1c3cea6d.jpeg
+updatedAt: 2026-08-20T10:01:25.222Z

--- a/registry/skins/yunxiiQwQ__dsh-maid-whale-webUI--maid-whale-webui.yml
+++ b/registry/skins/yunxiiQwQ__dsh-maid-whale-webUI--maid-whale-webui.yml
@@ -46,11 +46,8 @@ license:
   code: BSD-3-Clause
   commercialUse: true
 featuredRank: 22
-starsSnapshot: 16
+starsSnapshot: 18
 releaseUpdatedAt: 2026-08-16T12:48:35.081Z
-metadataUpdatedAt: 2026-08-20T06:33:00.085Z
-starsUpdatedAt: 2026-08-20T06:25:12.051Z
-updatedAt: 2026-08-20T06:33:00.085Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yunxiiQwQ__dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/152d5cd134c3.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yunxiiQwQ__dsh-maid-whale-webUI/f574f151bdfde7e8569797962eb8ff6aad4b3bf1/aa0c5d4b1f5c.webp
+metadataUpdatedAt: 2026-08-20T09:56:02.381Z
+starsUpdatedAt: 2026-08-20T09:56:02.381Z
+updatedAt: 2026-08-20T09:56:02.381Z

--- a/registry/skins/yuqisun__dsh-theme-machine.yml
+++ b/registry/skins/yuqisun__dsh-theme-machine.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 128
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-18T15:46:41.776Z
-metadataUpdatedAt: 2026-08-20T06:33:00.303Z
+metadataUpdatedAt: 2026-08-20T10:01:26.264Z
 starsUpdatedAt: 2026-08-16T13:58:28.052Z
-updatedAt: 2026-08-20T06:33:00.303Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yuqisun__dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/115439edfd98.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yuqisun__dsh-theme-machine/e7e7762e16ff6469fe9153e5d75bac1b37b0ef13/76cdff45d75b.png
+updatedAt: 2026-08-20T10:01:26.264Z

--- a/registry/skins/yushi-xxh__dsh-homepage-skin.yml
+++ b/registry/skins/yushi-xxh__dsh-homepage-skin.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 15
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-16T12:34:09.222Z
-metadataUpdatedAt: 2026-08-20T06:33:00.598Z
+metadataUpdatedAt: 2026-08-20T09:59:25.771Z
 starsUpdatedAt: 2026-08-18T15:43:54.246Z
-updatedAt: 2026-08-20T06:33:00.598Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yushi-xxh__dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/b35f325fdeab.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/yushi-xxh__dsh-homepage-skin/44933213da11f82caefd609ad1bdfe84ac95b3e0/b134c28d4b4f.png
+updatedAt: 2026-08-20T09:59:25.771Z

--- a/registry/skins/zealot00__dsh-pet.yml
+++ b/registry/skins/zealot00__dsh-pet.yml
@@ -45,9 +45,6 @@ license:
 featuredRank: 73
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16T13:51:35.527Z
-metadataUpdatedAt: 2026-08-20T06:33:01.200Z
+metadataUpdatedAt: 2026-08-20T09:57:22.092Z
 starsUpdatedAt: 2026-08-18T15:41:05.271Z
-updatedAt: 2026-08-20T06:33:01.200Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zealot00__dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/af59e6cbfa0e.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zealot00__dsh-pet/cb31dd4474f655e1caa87ed10d4403ba46a3f8b5/9c191f17a218.png
+updatedAt: 2026-08-20T09:57:22.092Z

--- a/registry/skins/zenghuizhu69-hub__dsh-skin-blue-whale.yml
+++ b/registry/skins/zenghuizhu69-hub__dsh-skin-blue-whale.yml
@@ -47,9 +47,6 @@ license:
 featuredRank: 56
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16T13:49:28.860Z
-metadataUpdatedAt: 2026-08-20T06:33:01.626Z
+metadataUpdatedAt: 2026-08-20T09:57:23.187Z
 starsUpdatedAt: 2026-08-16T13:49:28.860Z
-updatedAt: 2026-08-20T06:33:01.626Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zenghuizhu69-hub__dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/7976b6031fb4.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zenghuizhu69-hub__dsh-skin-blue-whale/6cf1b2125b01ec9180a7e65b7d707b53f5119334/182c7023e9ee.png
+updatedAt: 2026-08-20T09:57:23.187Z

--- a/registry/skins/zhijun-dai__Catppuccin-dsh-theme.yml
+++ b/registry/skins/zhijun-dai__Catppuccin-dsh-theme.yml
@@ -51,10 +51,6 @@ license:
 featuredRank: 3
 starsSnapshot: 9
 releaseUpdatedAt: 2026-08-18 15:39:27.744000+00:00
-metadataUpdatedAt: 2026-08-20T06:33:01.936Z
+metadataUpdatedAt: 2026-08-20T09:56:10.918Z
 starsUpdatedAt: 2026-08-18 15:39:27.744000+00:00
-updatedAt: 2026-08-20T06:33:01.936Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/5dbe9a6c0862.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/2ca5e4154728.webp
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhijun-dai__Catppuccin-dsh-theme/9885d3e7ee93ad4c972e92be4b6f301105e73eb4/db159c7e1bdc.webp
+updatedAt: 2026-08-20T09:56:10.918Z

--- a/registry/skins/zhijun-dai__Solarized-dsh-theme.yml
+++ b/registry/skins/zhijun-dai__Solarized-dsh-theme.yml
@@ -44,6 +44,6 @@ license:
 featuredRank: 12
 starsSnapshot: 3
 releaseUpdatedAt: 2026-08-16 12:32:51.434000+00:00
-metadataUpdatedAt: 2026-08-20T06:26:28.823Z
+metadataUpdatedAt: 2026-08-20T09:57:24.236Z
 starsUpdatedAt: 2026-08-18 15:41:08.372000+00:00
-updatedAt: 2026-08-20T06:26:28.823Z
+updatedAt: 2026-08-20T09:57:24.236Z

--- a/registry/skins/zhxqc__dsh-oh-my-theme.yml
+++ b/registry/skins/zhxqc__dsh-oh-my-theme.yml
@@ -46,10 +46,6 @@ license:
 featuredRank: 10
 starsSnapshot: 6
 releaseUpdatedAt: 2026-08-18 15:40:25.196000+00:00
-metadataUpdatedAt: 2026-08-20T06:33:02.231Z
+metadataUpdatedAt: 2026-08-20T09:56:48.136Z
 starsUpdatedAt: 2026-08-20T05:06:53.867Z
-updatedAt: 2026-08-20T06:33:02.231Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/3c7e8dd21f9b.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/0c248b74c981.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zhxqc__dsh-oh-my-theme/6dbea1ac6131abccea755551eb294a8cc4805786/ce9449df5314.png
+updatedAt: 2026-08-20T09:56:48.136Z

--- a/registry/skins/zsyayo112__dsh-rick-and-morty.yml
+++ b/registry/skins/zsyayo112__dsh-rick-and-morty.yml
@@ -46,10 +46,6 @@ license:
 featuredRank: 166
 starsSnapshot: 1
 releaseUpdatedAt: 2026-08-18T15:43:58.602Z
-metadataUpdatedAt: 2026-08-20T06:33:02.421Z
+metadataUpdatedAt: 2026-08-20T09:59:30.849Z
 starsUpdatedAt: 2026-08-18T15:43:58.602Z
-updatedAt: 2026-08-20T06:33:02.421Z
-marketScreenshots:
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/a6ebf0060d27.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/6f0ead310d16.png
-  - https://kingofsoysauce.github.io/dsh-skin-market/skin-screenshots/zsyayo112__dsh-rick-and-morty/83dfc64c0f53da29b7b7e70c83ea8be11416a6b3/a67c82b7faed.png
+updatedAt: 2026-08-20T09:59:30.849Z


### PR DESCRIPTION
Automated registry refresh from the private DSH skin market operations repository. The detailed ingestion report is attached to the workflow run.