### PR TITLE
feat(registry): update dsh-skin-rotator to 1f91b08 (cross-fade rotation)

### DIFF
--- a/registry/skins/wensincai__dsh-skin-rotator.yml
+++ b/registry/skins/wensincai__dsh-skin-rotator.yml
@@ -16,15 +16,15 @@ tags:
 modes:
   - dark
 install:
-  target: github:wensincai/dsh-skin-rotator#a04cdc926dec980ef946731318d74d4e44167dac
+  target: github:wensincai/dsh-skin-rotator#1f91b08cb59c3b1f5e47db7f071bcde36f89d9ea
   version: 0.1.1
-  commit: a04cdc926dec980ef946731318d74d4e44167dac
+  commit: 1f91b08cb59c3b1f5e47db7f071bcde36f89d9ea
 compatibility:
   dsh: 0.1.0-rc.6
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/wensincai/dsh-skin-rotator/a04cdc926dec980ef946731318d74d4e44167dac/docs/screenshot.png
+  - https://raw.githubusercontent.com/wensincai/dsh-skin-rotator/1f91b08cb59c3b1f5e47db7f071bcde36f89d9ea/docs/screenshot.png
 review:
   compatibility: unverified
   preview: verified


### PR DESCRIPTION
Re-pin dsh-skin-rotator from a04cdc9 to 1f91b08.

Changes in the new commit (all client-side):
- Wallpaper moved to a dedicated fixed layer (z-index -1) so shell surfaces can never cover it
- Next image is preloaded before the swap: no flash mid-rotation
- 0.5s cross-fade transition on rotation
- Black veil follows the theme (pure black light / near-black navy dark), still driven by overlayOpacity
- MutationObserver re-seals transparent surfaces after React remounts

registry:check passes (142 skins). Screenshot URL re-pinned to the new commit.