### PR TITLE
feat(registry): add dsh-Furina-theme

### DIFF
--- a/registry/skins/UniverFV__dsh-Furina-theme.yml
+++ b/registry/skins/UniverFV__dsh-Furina-theme.yml
@@ -20,17 +20,17 @@ modes:
   - light
   - dark
 install:
-  target: github:UniverFV/dsh-Furina-theme#077924ee8a46deaf3d0865434b4e58bccea9708e
+  target: github:UniverFV/dsh-Furina-theme#018aa161452d7356bf3dfbb0f8baa517ae386ce6
   version: 0.1.0
-  commit: 077924ee8a46deaf3d0865434b4e58bccea9708e
+  commit: 018aa161452d7356bf3dfbb0f8baa517ae386ce6
 compatibility:
   dsh: ">=0.1.0-rc.8"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/077924ee8a46deaf3d0865434b4e58bccea9708e/docs/preview/light.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/077924ee8a46deaf3d0865434b4e58bccea9708e/docs/preview/dark.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/077924ee8a46deaf3d0865434b4e58bccea9708e/docs/preview/settings.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/018aa161452d7356bf3dfbb0f8baa517ae386ce6/docs/preview/light.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/018aa161452d7356bf3dfbb0f8baa517ae386ce6/docs/preview/dark.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/018aa161452d7356bf3dfbb0f8baa517ae386ce6/docs/preview/settings.png
 review:
   compatibility: verified
   preview: verified

--- a/registry/skins/UniverFV__dsh-Furina-theme.yml
+++ b/registry/skins/UniverFV__dsh-Furina-theme.yml
@@ -20,17 +20,17 @@ modes:
   - light
   - dark
 install:
-  target: github:UniverFV/dsh-Furina-theme#018aa161452d7356bf3dfbb0f8baa517ae386ce6
+  target: github:UniverFV/dsh-Furina-theme#23a334a6d7b9dd761a6eda3f78601305b195512b
   version: 0.1.0
-  commit: 018aa161452d7356bf3dfbb0f8baa517ae386ce6
+  commit: 23a334a6d7b9dd761a6eda3f78601305b195512b
 compatibility:
   dsh: ">=0.1.0-rc.8"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/018aa161452d7356bf3dfbb0f8baa517ae386ce6/docs/preview/light.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/018aa161452d7356bf3dfbb0f8baa517ae386ce6/docs/preview/dark.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/018aa161452d7356bf3dfbb0f8baa517ae386ce6/docs/preview/settings.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/23a334a6d7b9dd761a6eda3f78601305b195512b/docs/preview/light.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/23a334a6d7b9dd761a6eda3f78601305b195512b/docs/preview/dark.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/23a334a6d7b9dd761a6eda3f78601305b195512b/docs/preview/settings.png
 review:
   compatibility: verified
   preview: verified

--- a/registry/skins/UniverFV__dsh-Furina-theme.yml
+++ b/registry/skins/UniverFV__dsh-Furina-theme.yml
@@ -20,16 +20,17 @@ modes:
   - light
   - dark
 install:
-  target: github:UniverFV/dsh-Furina-theme#0c5d748d919a63905452084fdd761e56ae3026be
+  target: github:UniverFV/dsh-Furina-theme#278c18ba66eb00909c1dc7637654165701bfaae2
   version: 0.1.0
-  commit: 0c5d748d919a63905452084fdd761e56ae3026be
+  commit: 278c18ba66eb00909c1dc7637654165701bfaae2
 compatibility:
   dsh: ">=0.1.0-rc.8"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/0c5d748d919a63905452084fdd761e56ae3026be/docs/preview/display1.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/0c5d748d919a63905452084fdd761e56ae3026be/docs/preview/display2.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/278c18ba66eb00909c1dc7637654165701bfaae2/docs/preview/display3.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/278c18ba66eb00909c1dc7637654165701bfaae2/docs/preview/display4.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/278c18ba66eb00909c1dc7637654165701bfaae2/docs/preview/display5.png
 review:
   compatibility: verified
   preview: verified

--- a/registry/skins/UniverFV__dsh-Furina-theme.yml
+++ b/registry/skins/UniverFV__dsh-Furina-theme.yml
@@ -20,17 +20,16 @@ modes:
   - light
   - dark
 install:
-  target: github:UniverFV/dsh-Furina-theme#23a334a6d7b9dd761a6eda3f78601305b195512b
+  target: github:UniverFV/dsh-Furina-theme#0c5d748d919a63905452084fdd761e56ae3026be
   version: 0.1.0
-  commit: 23a334a6d7b9dd761a6eda3f78601305b195512b
+  commit: 0c5d748d919a63905452084fdd761e56ae3026be
 compatibility:
   dsh: ">=0.1.0-rc.8"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/23a334a6d7b9dd761a6eda3f78601305b195512b/docs/preview/light.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/23a334a6d7b9dd761a6eda3f78601305b195512b/docs/preview/dark.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/23a334a6d7b9dd761a6eda3f78601305b195512b/docs/preview/settings.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/0c5d748d919a63905452084fdd761e56ae3026be/docs/preview/display1.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/0c5d748d919a63905452084fdd761e56ae3026be/docs/preview/display2.png
 review:
   compatibility: verified
   preview: verified

--- a/registry/skins/UniverFV__dsh-Furina-theme.yml
+++ b/registry/skins/UniverFV__dsh-Furina-theme.yml
@@ -1,0 +1,56 @@
+id: univerfv.dsh-furina-theme
+name:
+  zh: 芙宁娜主题
+  en: Furina Theme
+author: UniverFV
+description: 芙宁娜主题皮肤：水蓝 × 藏青 × 冰白 × 神之眼金色板，微信/QQ 式聊天气泡，双形态焦点模式（非输入时壁纸清晰、输入时自动雾化），壁纸亮度自适应与液态流动动效。
+repo: https://github.com/UniverFV/dsh-Furina-theme
+package: dsh-furina-theme
+rowId: furina-theme
+category: theme
+tags:
+  - furina
+  - genshin
+  - wallpaper
+  - glass
+  - liquid
+  - motion
+  - light-dark
+modes:
+  - light
+  - dark
+install:
+  target: github:UniverFV/dsh-Furina-theme#077924ee8a46deaf3d0865434b4e58bccea9708e
+  version: 0.1.0
+  commit: 077924ee8a46deaf3d0865434b4e58bccea9708e
+compatibility:
+  dsh: ">=0.1.0-rc.8"
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/077924ee8a46deaf3d0865434b4e58bccea9708e/docs/preview/light.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/077924ee8a46deaf3d0865434b4e58bccea9708e/docs/preview/dark.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/077924ee8a46deaf3d0865434b4e58bccea9708e/docs/preview/settings.png
+review:
+  compatibility: verified
+  preview: verified
+  installation: manual-only
+health:
+  status: improvements
+  checks:
+    readmeScreenshots: pass
+    compatibility: pass
+    installation: pass
+    installCommand: pass
+    topic: improve
+  suggestions:
+    - 仓库创建后请添加 dsh-plugin GitHub topic，便于市场与社区发现
+license:
+  code: MIT
+  commercialUse: true
+featuredRank: 0
+starsSnapshot: 0
+releaseUpdatedAt: 2026-08-21T12:00:00.000Z
+metadataUpdatedAt: 2026-08-21T12:00:00.000Z
+starsUpdatedAt: 2026-08-21T12:00:00.000Z
+updatedAt: 2026-08-21T12:00:00.000Z

--- a/registry/skins/UniverFV__dsh-Furina-theme.yml
+++ b/registry/skins/UniverFV__dsh-Furina-theme.yml
@@ -20,17 +20,17 @@ modes:
   - light
   - dark
 install:
-  target: github:UniverFV/dsh-Furina-theme#278c18ba66eb00909c1dc7637654165701bfaae2
+  target: github:UniverFV/dsh-Furina-theme#b2d8d2014f3a6c354322a4a9c551bccabead26c6
   version: 0.1.0
-  commit: 278c18ba66eb00909c1dc7637654165701bfaae2
+  commit: b2d8d2014f3a6c354322a4a9c551bccabead26c6
 compatibility:
   dsh: ">=0.1.0-rc.8"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/278c18ba66eb00909c1dc7637654165701bfaae2/docs/preview/display3.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/278c18ba66eb00909c1dc7637654165701bfaae2/docs/preview/display4.png
-  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/278c18ba66eb00909c1dc7637654165701bfaae2/docs/preview/display5.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/b2d8d2014f3a6c354322a4a9c551bccabead26c6/docs/preview/display3.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/b2d8d2014f3a6c354322a4a9c551bccabead26c6/docs/preview/display4.png
+  - https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/b2d8d2014f3a6c354322a4a9c551bccabead26c6/docs/preview/display5.png
 review:
   compatibility: verified
   preview: verified


### PR DESCRIPTION
新增皮肤：芙宁娜主题（dsh-Furina-theme）

## 基本信息

- **中文名**：芙宁娜主题（Furina Theme）
- **仓库**：https://github.com/UniverFV/dsh-Furina-theme
- **子包**：无（单包仓库）
- **包名**：`dsh-furina-theme`
- **rowId**：`furina-theme`
- **版本**：0.1.0
- **commit**：`b2d8d2014f3a6c354322a4a9c551bccabead26c6`（固定 40 位 SHA，非可变分支）
- **许可证**：MIT（代码）；壁纸为 AI 生成素材，素材清单见仓库 `docs/wallpapers.md`
- **兼容性**：DSH `>= 0.1.0-rc.8`，platform: `web`（已在真实 rc.8 Web profile 上安装验证：bundle 挂载、壁纸路由、设置行均正常）
- **模式**：light + dark（浅色/深色双模式，壁纸亮度自适应翻转）

## 功能摘要

- 微信/QQ 式聊天气泡（用户蓝泡 + 小三角 / AI 白泡 + 小三角，工具调用同款气泡）
- 双形态焦点模式：非输入时壁纸清晰（消息淡出），输入时壁纸自动雾化 + 文字可读
- 输入框收纳：非输入模式下小箭头收起/展开输入框，按键与状态胶囊随之沉底/升起，悬停才浮现
- 状态胶囊：AI 正在输入 / 新消息红点计数
- 壁纸按浅色/深色/通用分类选择，自动按主题模式推荐；支持自定义壁纸（设置内直接添加本地图片，自动压缩存储，最多 6 张）

## 展示截图（仓库内实机截图，固定 commit raw 链接）

- https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/b2d8d2014f3a6c354322a4a9c551bccabead26c6/docs/preview/display3.png
- https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/b2d8d2014f3a6c354322a4a9c551bccabead26c6/docs/preview/display4.png
- https://raw.githubusercontent.com/UniverFV/dsh-Furina-theme/b2d8d2014f3a6c354322a4a9c551bccabead26c6/docs/preview/display5.png

## 自动检查结果

- `npm run registry:check`：通过（202 个条目全部校验，catalog 未写入）
- `npm run smoke:submission`：56/56 通过
- 本 PR 变更范围：仅新增 `registry/skins/UniverFV__dsh-Furina-theme.yml`（`git diff --name-only` 确认）

## 仍需人工确认的风险

- 仓库已创建但尚未添加 `dsh-plugin` GitHub topic（创建者需在仓库设置中补充）
- 皮肤基于 DSH rc.8 实测，后续 DSH 大版本升级可能需要跟进适配
