### PR TITLE
fix(desktop): route plugin add through the recoverable install boundary

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -115,7 +115,21 @@ export function desktopRunner(service, profileDir) {
         let timedOut = false;
         const timer = setTimeout(() => { timedOut = true; timeout.abort(); }, PLUGIN_COMMAND_TIMEOUT_MS);
         const signal = options?.signal === undefined ? timeout.signal : AbortSignal.any([options.signal, timeout.signal]);
-        const operation = service.runPlugin(args, profileDir, signal, normalizedEnvironment(options));
+        // Desktop hosts reject `plugin add` through runPlugin: profile-mutating
+        // installs must cross the recoverable install boundary. Adds that carry
+        // an installRecovery record use runPluginInstall; adds redirected into a
+        // temporary directory (prefetch) never touch the profile, so they run
+        // through the packaged pnpm directly.
+        let operation;
+        if (args[0] === 'add' && options?.installRecovery !== undefined && typeof service.runPluginInstall === 'function') {
+            operation = await service.runPluginInstall(args, profileDir, options.installRecovery, signal);
+        }
+        else if (args[0] === 'add' && args.includes('--dir') && typeof service.run === 'function') {
+            operation = service.run(args, signal);
+        }
+        else {
+            operation = service.runPlugin(args, profileDir, signal, normalizedEnvironment(options));
+        }
         let stdout = '';
         let stderr = '';
         operation.stdout.on('data', chunk => {

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -268,7 +268,7 @@ export class SkinLifecycle {
             timer.unref?.();
         }
     }
-    async run(args, operation) {
+    async run(args, operation, extra) {
         const controller = operation === undefined ? undefined : this.abortControllers.get(operation.id);
         if (controller?.signal.aborted === true)
             throw new Error('操作已取消');
@@ -278,6 +278,7 @@ export class SkinLifecycle {
             signal: controller?.signal,
             onStdout: chunk => tracker?.push(chunk, operation),
             onStderr: chunk => tracker?.push(chunk, operation),
+            ...extra,
         });
         if (result.exitCode !== 0 || result.timedOut)
             throw new Error(commandError(result));
@@ -327,7 +328,12 @@ export class SkinLifecycle {
             this.update(operation, 'installing');
             if (skin.install.allowBuild !== undefined)
                 ensureBuildAllowed(this.options.profileDir, skin.install.allowBuild);
-            await this.run(['add', skin.install.target, '--prefer-offline'], operation);
+            // Desktop hosts require profile-mutating adds to cross the recoverable
+            // install boundary; attach the recovery record so the desktop runner can
+            // route through runPluginInstall.
+            await this.run(['add', skin.install.target, '--prefer-offline'], operation, {
+                installRecovery: { packageName: skin.package, packageVersion: skin.install.version, receiptId: randomUUID() },
+            });
             this.update(operation, 'validating');
             const validation = validateInstalledSkin(this.options.profileDir, skin);
             if (!validation.ok)
@@ -461,7 +467,12 @@ export class SkinLifecycle {
             this.update(operation, 'installing');
             if (skin.install.allowBuild !== undefined)
                 ensureBuildAllowed(this.options.profileDir, skin.install.allowBuild);
-            await this.run(['add', skin.install.target, '--prefer-offline'], operation);
+            // Desktop hosts require profile-mutating adds to cross the recoverable
+            // install boundary; attach the recovery record so the desktop runner can
+            // route through runPluginInstall.
+            await this.run(['add', skin.install.target, '--prefer-offline'], operation, {
+                installRecovery: { packageName: skin.package, packageVersion: skin.install.version, receiptId: randomUUID() },
+            });
             this.update(operation, 'validating');
             const validation = validateInstalledSkin(this.options.profileDir, skin);
             if (!validation.ok || validation.version !== skin.install.version)

--- a/lib/types/commands.d.ts
+++ b/lib/types/commands.d.ts
@@ -10,6 +10,18 @@ export interface CommandOptions {
     env?: NodeJS.ProcessEnv;
     onStdout?: (chunk: string) => void;
     onStderr?: (chunk: string) => void;
+    /**
+     * Recovery record for a profile-mutating `add`. Desktop hosts reject
+     * `plugin add` through the plain plugin runner ("plugin add must use the
+     * recoverable install boundary"); when present, the desktop runner routes
+     * the add through runPluginInstall with this record.
+     */
+    installRecovery?: InstallRecoveryRecord;
+}
+export interface InstallRecoveryRecord {
+    packageName: string;
+    packageVersion: string;
+    receiptId: string;
 }
 export type PluginRunner = (profile: string, args: readonly string[], options?: CommandOptions) => Promise<CommandResult>;
 export declare function normalizedEnvironment(options?: CommandOptions): NodeJS.ProcessEnv | undefined;
@@ -19,14 +31,20 @@ export declare function quoteCmdArg(arg: string): string;
 /** Build the command line used by the explicit Windows cmd.exe bridge. */
 export declare function cmdCommandLine(argv: readonly string[]): string;
 export declare const runPluginCli: PluginRunner;
+interface DesktopOperationHandle {
+    stdout: NodeJS.ReadableStream;
+    stderr: NodeJS.ReadableStream;
+    done: Promise<{
+        exitCode: number | null;
+    }>;
+}
 export interface DesktopPnpmLike {
-    runPlugin(args: readonly string[], invokingDir: string, signal?: AbortSignal, env?: NodeJS.ProcessEnv): {
-        stdout: NodeJS.ReadableStream;
-        stderr: NodeJS.ReadableStream;
-        done: Promise<{
-            exitCode: number | null;
-        }>;
-    };
+    runPlugin(args: readonly string[], invokingDir: string, signal?: AbortSignal, env?: NodeJS.ProcessEnv): DesktopOperationHandle;
+    /** Packaged pnpm in the active profile; present on desktop hosts that gate `plugin add`. */
+    run?(args: readonly string[], signal?: AbortSignal): DesktopOperationHandle;
+    /** Recoverable install boundary: WAL-snapshots the profile around one `add`. */
+    runPluginInstall?(args: readonly string[], invokingDir: string, recovery: InstallRecoveryRecord, signal?: AbortSignal): Promise<DesktopOperationHandle>;
 }
 export declare function desktopRunner(service: DesktopPnpmLike, profileDir: string): PluginRunner;
 export declare function commandError(result: CommandResult): string;
+export {};

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,6 +14,19 @@ export interface CommandOptions {
   env?: NodeJS.ProcessEnv
   onStdout?: (chunk: string) => void
   onStderr?: (chunk: string) => void
+  /**
+   * Recovery record for a profile-mutating `add`. Desktop hosts reject
+   * `plugin add` through the plain plugin runner ("plugin add must use the
+   * recoverable install boundary"); when present, the desktop runner routes
+   * the add through runPluginInstall with this record.
+   */
+  installRecovery?: InstallRecoveryRecord
+}
+
+export interface InstallRecoveryRecord {
+  packageName: string
+  packageVersion: string
+  receiptId: string
 }
 
 export type PluginRunner = (profile: string, args: readonly string[], options?: CommandOptions) => Promise<CommandResult>
@@ -127,12 +140,18 @@ export const runPluginCli: PluginRunner = (profile, args, options) => new Promis
   })
 })
 
+interface DesktopOperationHandle {
+  stdout: NodeJS.ReadableStream
+  stderr: NodeJS.ReadableStream
+  done: Promise<{ exitCode: number | null }>
+}
+
 export interface DesktopPnpmLike {
-  runPlugin(args: readonly string[], invokingDir: string, signal?: AbortSignal, env?: NodeJS.ProcessEnv): {
-    stdout: NodeJS.ReadableStream
-    stderr: NodeJS.ReadableStream
-    done: Promise<{ exitCode: number | null }>
-  }
+  runPlugin(args: readonly string[], invokingDir: string, signal?: AbortSignal, env?: NodeJS.ProcessEnv): DesktopOperationHandle
+  /** Packaged pnpm in the active profile; present on desktop hosts that gate `plugin add`. */
+  run?(args: readonly string[], signal?: AbortSignal): DesktopOperationHandle
+  /** Recoverable install boundary: WAL-snapshots the profile around one `add`. */
+  runPluginInstall?(args: readonly string[], invokingDir: string, recovery: InstallRecoveryRecord, signal?: AbortSignal): Promise<DesktopOperationHandle>
 }
 
 export function desktopRunner(service: DesktopPnpmLike, profileDir: string): PluginRunner {
@@ -141,7 +160,19 @@ export function desktopRunner(service: DesktopPnpmLike, profileDir: string): Plu
     let timedOut = false
     const timer = setTimeout(() => { timedOut = true; timeout.abort() }, PLUGIN_COMMAND_TIMEOUT_MS)
     const signal = options?.signal === undefined ? timeout.signal : AbortSignal.any([options.signal, timeout.signal])
-    const operation = service.runPlugin(args, profileDir, signal, normalizedEnvironment(options))
+    // Desktop hosts reject `plugin add` through runPlugin: profile-mutating
+    // installs must cross the recoverable install boundary. Adds that carry
+    // an installRecovery record use runPluginInstall; adds redirected into a
+    // temporary directory (prefetch) never touch the profile, so they run
+    // through the packaged pnpm directly.
+    let operation: DesktopOperationHandle
+    if (args[0] === 'add' && options?.installRecovery !== undefined && typeof service.runPluginInstall === 'function') {
+      operation = await service.runPluginInstall(args, profileDir, options.installRecovery, signal)
+    } else if (args[0] === 'add' && args.includes('--dir') && typeof service.run === 'function') {
+      operation = service.run(args, signal)
+    } else {
+      operation = service.runPlugin(args, profileDir, signal, normalizedEnvironment(options))
+    }
     let stdout = ''
     let stderr = ''
     operation.stdout.on('data', chunk => {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { PluginRunner } from './commands.ts'
+import type { CommandOptions, PluginRunner } from './commands.ts'
 import { commandError } from './commands.ts'
 import { loadCatalog } from './catalog.ts'
 import {
@@ -289,7 +289,7 @@ export class SkinLifecycle {
     }
   }
 
-  private async run(args: readonly string[], operation?: Operation): Promise<void> {
+  private async run(args: readonly string[], operation?: Operation, extra?: Pick<CommandOptions, 'installRecovery'>): Promise<void> {
     const controller = operation === undefined ? undefined : this.abortControllers.get(operation.id)
     if (controller?.signal.aborted === true) throw new Error('操作已取消')
     const tracker = operation === undefined ? undefined : new PnpmProgressTracker()
@@ -298,6 +298,7 @@ export class SkinLifecycle {
       signal: controller?.signal,
       onStdout: chunk => tracker?.push(chunk, operation!),
       onStderr: chunk => tracker?.push(chunk, operation!),
+      ...extra,
     })
     if (result.exitCode !== 0 || result.timedOut) throw new Error(commandError(result))
   }
@@ -345,7 +346,12 @@ export class SkinLifecycle {
       await this.prefetch(skin.install.target, operation)
       this.update(operation, 'installing')
       if (skin.install.allowBuild !== undefined) ensureBuildAllowed(this.options.profileDir, skin.install.allowBuild)
-      await this.run(['add', skin.install.target, '--prefer-offline'], operation)
+      // Desktop hosts require profile-mutating adds to cross the recoverable
+      // install boundary; attach the recovery record so the desktop runner can
+      // route through runPluginInstall.
+      await this.run(['add', skin.install.target, '--prefer-offline'], operation, {
+        installRecovery: { packageName: skin.package, packageVersion: skin.install.version, receiptId: randomUUID() },
+      })
       this.update(operation, 'validating')
       const validation = validateInstalledSkin(this.options.profileDir, skin)
       if (!validation.ok) throw new Error(validation.reason)
@@ -469,7 +475,12 @@ export class SkinLifecycle {
       await this.prefetch(skin.install.target, operation)
       this.update(operation, 'installing')
       if (skin.install.allowBuild !== undefined) ensureBuildAllowed(this.options.profileDir, skin.install.allowBuild)
-      await this.run(['add', skin.install.target, '--prefer-offline'], operation)
+      // Desktop hosts require profile-mutating adds to cross the recoverable
+      // install boundary; attach the recovery record so the desktop runner can
+      // route through runPluginInstall.
+      await this.run(['add', skin.install.target, '--prefer-offline'], operation, {
+        installRecovery: { packageName: skin.package, packageVersion: skin.install.version, receiptId: randomUUID() },
+      })
       this.update(operation, 'validating')
       const validation = validateInstalledSkin(this.options.profileDir, skin)
       if (!validation.ok || validation.version !== skin.install.version) throw new Error(validation.reason ?? 'installed version did not change to the reviewed version')


### PR DESCRIPTION
## Problem

On DSH Desktop, every skin install/update fails after ~1 second with:

```
dsh-plugin-desktop: plugin add must use the recoverable install boundary
```

Desktop hosts now hard-reject `plugin add` through the plain plugin runner (`runPlugin`). Profile-mutating installs must cross the **recoverable install boundary** (`runPluginInstall`), which WAL-snapshots the active profile so a bad install can be rolled back at the next startup (the official `dsh-community-market` already uses it). `dsh-skin-market`'s desktop runner still routes `add` through `runPlugin`, so installs are dead on desktop — including the *prefetch* step, which also uses `add` (into a temp dir) and hits the same guard before the real install even starts.

## Fix

- `desktopRunner` now routes three ways:
  - `add` carrying an `installRecovery` record → `service.runPluginInstall(...)` (the sanctioned boundary)
  - `add --dir <tmp>` (prefetch; never touches the profile) → `service.run(...)` (packaged pnpm directly, no WAL noise)
  - everything else (`remove`, `install`, …) → `runPlugin` as before
- `lifecycle.install()` / `updateSkin()` attach `{ packageName, packageVersion, receiptId }` to the profile-mutating `add`; `run()` forwards extra runner options.

All new service methods are feature-detected (`typeof … === 'function'`), so older hosts without the boundary keep working unchanged.

## Verification

- `tsc -p tsconfig.json --noEmit` clean; `lib/` rebuilt with `tsc -p tsconfig.json` and committed.
- Route-tested against a stubbed `DesktopPnpmLike`: profile add → `runPluginInstall` with the recovery record; prefetch add → `run`; `remove` → `runPlugin`.
- Applied as a `patchedDependencies` patch on a live DSH Desktop profile: skin install then succeeded end-to-end (registry GitHub target), and the post-install restart surfaced the host's recovery-verification window as designed.

## Note for reviewers

The recovery lifecycle is fully host-owned: a verified transaction is cleared by the host on healthy boot; a rolled-back foreign receipt id is harmlessly acknowledged by the community market's startup reconciliation. The receipt id this plugin generates does not need to live in the community market's receipt store.
