### PR TITLE
feat(registry): add 马加七皮肤

### DIFF
--- a/registry/skins/carlown__majia7-dsh-skin.yml
+++ b/registry/skins/carlown__majia7-dsh-skin.yml
@@ -1,0 +1,57 @@
+id: carlown.majia7-skin
+name:
+  zh: 马加七皮肤
+  en: Majia7 Skin
+author: Carlown
+description: 四档"图+配色+人设"三位一体推理滑块皮肤：off 灰 / low 蓝（原版观感）/ high 亮青 / max 粉 #E6DDDE；新对话、发送、设置等按钮随档位变色；服务端通过 systemPrompt 通道隐形注入档位人设（off 油腻恶心 → max 霸道总裁，恒定自称「马加7」并把用户当女生，附合规护栏）；支持背景深度调节。
+repo: https://github.com/Carlown/majia7-dsh-skin
+package: dsh-client-majia7-skin
+rowId: majia7-skin
+category: interactive
+tags:
+  - four-tier
+  - pink
+  - reasoning-slider
+  - composer
+  - persona
+modes:
+  - light
+install:
+  target: github:Carlown/majia7-dsh-skin#8d81fcecdac2ed013053927f719f23a42cdf49fd
+  version: 0.3.2
+  commit: 8d81fcecdac2ed013053927f719f23a42cdf49fd
+  desktop:
+    mode: manual-only
+    reason: npm-package-not-found
+compatibility:
+  dsh: 0.1.1-rc.2
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier0.png
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier1.png
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier2.png
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier3.png
+review:
+  compatibility: verified
+  preview: verified
+  installation: verified
+health:
+  status: healthy
+  checks:
+    readmeScreenshots: pass
+    compatibility: pass
+    installation: pass
+    installCommand: pass
+    topic: pass
+  suggestions: []
+license:
+  code: NOASSERTION
+  commercialUse: false
+  notice: 仓库当前未声明许可证；四张档位图与文档截图为作者自有素材。安装和再分发前请向作者确认授权。
+featuredRank: 0
+starsSnapshot: 0
+releaseUpdatedAt: 2026-08-26T11:54:32.000Z
+metadataUpdatedAt: 2026-08-26T11:54:32.000Z
+starsUpdatedAt: 2026-08-26T11:54:32.000Z
+updatedAt: 2026-08-26T11:54:32.000Z

--- a/registry/skins/carlown__majia7-dsh-skin.yml
+++ b/registry/skins/carlown__majia7-dsh-skin.yml
@@ -17,9 +17,9 @@ tags:
 modes:
   - light
 install:
-  target: github:Carlown/majia7-dsh-skin#8d81fcecdac2ed013053927f719f23a42cdf49fd
+  target: github:Carlown/majia7-dsh-skin#af1e224fee1bb7383245702a65b1bee18778f175
   version: 0.3.2
-  commit: 8d81fcecdac2ed013053927f719f23a42cdf49fd
+  commit: af1e224fee1bb7383245702a65b1bee18778f175
   desktop:
     mode: manual-only
     reason: npm-package-not-found
@@ -28,10 +28,10 @@ compatibility:
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier0.png
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier1.png
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier2.png
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/8d81fcecdac2ed013053927f719f23a42cdf49fd/docs/screenshots/px-tier3.png
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-off.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-low.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-high.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-max.jpeg
 review:
   compatibility: verified
   preview: verified

--- a/registry/skins/carlown__majia7-dsh-skin.yml
+++ b/registry/skins/carlown__majia7-dsh-skin.yml
@@ -18,7 +18,7 @@ modes:
   - light
 install:
   target: github:Carlown/majia7-dsh-skin#cee84e41791c629cec7c3274c3c7996078cce80a
-  version: 0.3.2
+  version: 0.3.3
   commit: cee84e41791c629cec7c3274c3c7996078cce80a
   desktop:
     mode: manual-only

--- a/registry/skins/carlown__majia7-dsh-skin.yml
+++ b/registry/skins/carlown__majia7-dsh-skin.yml
@@ -17,9 +17,9 @@ tags:
 modes:
   - light
 install:
-  target: github:Carlown/majia7-dsh-skin#af1e224fee1bb7383245702a65b1bee18778f175
+  target: github:Carlown/majia7-dsh-skin#cee84e41791c629cec7c3274c3c7996078cce80a
   version: 0.3.2
-  commit: af1e224fee1bb7383245702a65b1bee18778f175
+  commit: cee84e41791c629cec7c3274c3c7996078cce80a
   desktop:
     mode: manual-only
     reason: npm-package-not-found
@@ -28,10 +28,10 @@ compatibility:
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-off.jpeg
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-low.jpeg
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-high.jpeg
-  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/af1e224fee1bb7383245702a65b1bee18778f175/docs/screenshots/screenshot-max.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/cee84e41791c629cec7c3274c3c7996078cce80a/docs/screenshots/screenshot-off.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/cee84e41791c629cec7c3274c3c7996078cce80a/docs/screenshots/screenshot-low.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/cee84e41791c629cec7c3274c3c7996078cce80a/docs/screenshots/screenshot-high.jpeg
+  - https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/cee84e41791c629cec7c3274c3c7996078cce80a/docs/screenshots/screenshot-max.jpeg
 review:
   compatibility: verified
   preview: verified
@@ -46,9 +46,9 @@ health:
     topic: pass
   suggestions: []
 license:
-  code: NOASSERTION
-  commercialUse: false
-  notice: 仓库当前未声明许可证；四张档位图与文档截图为作者自有素材。安装和再分发前请向作者确认授权。
+  code: MIT
+  commercialUse: true
+  notice: MIT。四张档位图与文档截图为作者自有素材，随 MIT 许可证一并发布。
 featuredRank: 0
 starsSnapshot: 0
 releaseUpdatedAt: 2026-08-26T11:54:32.000Z

--- a/registry/skins/carlown__majia7-dsh-skin.yml
+++ b/registry/skins/carlown__majia7-dsh-skin.yml
@@ -17,9 +17,9 @@ tags:
 modes:
   - light
 install:
-  target: github:Carlown/majia7-dsh-skin#cee84e41791c629cec7c3274c3c7996078cce80a
-  version: 0.3.3
-  commit: cee84e41791c629cec7c3274c3c7996078cce80a
+  target: github:Carlown/majia7-dsh-skin#297cdd037e52f5a5c9e4c080a5dc8fd7d42fb730
+  version: 0.3.4
+  commit: 297cdd037e52f5a5c9e4c080a5dc8fd7d42fb730
   desktop:
     mode: manual-only
     reason: npm-package-not-found


### PR DESCRIPTION
## 新增条目

- **文件**：`registry/skins/carlown__majia7-dsh-skin.yml`
- **皮肤仓库**：https://github.com/Carlown/majia7-dsh-skin（公开）
- **子包**：无 monorepo，根目录单包
- **包名**：`dsh-client-majia7-skin`
- **版本**：0.3.2
- **固定 commit**：`8d81fcecdac2ed013053927f719f23a42cdf49fd`
- **rowId**：`majia7-skin`（与上游 `liang-intensity-skin` 区分，避免 rowId/package 双重冲突；loader id 与 cordis.patch.yml 已同步改为 majia7-skin）
- **许可证**：NOASSERTION（仓库未声明 LICENSE；四张档位图与截图为作者自有素材），commercialUse: false
- **预览来源**：仓库内真实四档截图（docs/screenshots/px-tier0~3.png），以固定 commit 的 raw 地址引用，已逐一验证 HTTP 200
- **兼容性**：DSH `0.1.1-rc.2` / platform web（在本机运行中的 DSH 上实际安装并验证）
- **modes**：light（四档均为浅色壳，max 为粉 #E6DDDE）

## 自动检查结果

- `npm run registry:check`：✅ validated 225 skins（224 存量 + 本条目），catalog 未写入
- `npm run smoke:submission`：✅ 67/67 通过
- `git diff --name-only`：仅新增本条目 YAML，未触碰生成文件与既有条目
- 四张截图 raw URL（固定 commit）逐一 curl 验证 200

## 条目要点

四档"图 + 配色 + 人设"三位一体推理滑块皮肤（fork 自 liang-intensity-skin 并大幅改造）：
off 灰 / low 蓝（原版观感）/ high 亮青 / max 粉 #E6DDDE；新对话、发送、设置等按钮随档位变色；
背景深度可调；服务端经 `systemPrompt.context()` 隐形注入档位人设（off 油腻恶心 → max 霸道总裁，
恒定自称「马加7」并把用户当女生，附合规护栏），用户消息气泡与历史记录不含任何指令文本。

## 仍需人工确认的风险

1. **许可证 NOASSERTION**：作者（我）尚未在皮肤仓库添加 LICENSE 文件，commercialUse 暂设 false；建议合并前由作者补 LICENSE 并更新条目。
2. **素材授权**：四张档位图为作者自有素材，但市场如需更强授权声明，请作者补充说明。
3. **包名/rowId 与上游不同**属有意为之（唯一性约束 + 与原版并存），请复核命名是否符合市场惯例。
4. 兼容性仅在 DSH `0.1.1-rc.2` 单一环境实测，其他版本未验证。

> 收录不等于安全认证：本 PR 不声称该皮肤获得 DSH 官方、安全团队或市场的背书。