### PR TITLE
feat(registry): update 马加七皮肤 to v0.3.6

### DIFF
--- a/registry/skins/carlown__majia7-dsh-skin.yml
+++ b/registry/skins/carlown__majia7-dsh-skin.yml
@@ -17,9 +17,9 @@ tags:
 modes:
   - light
 install:
-  target: github:Carlown/majia7-dsh-skin#297cdd037e52f5a5c9e4c080a5dc8fd7d42fb730
-  version: 0.3.4
-  commit: 297cdd037e52f5a5c9e4c080a5dc8fd7d42fb730
+  target: github:Carlown/majia7-dsh-skin#1b326bda8e085cba59aa83b81251fd37cbf32b93
+  version: 0.3.6
+  commit: 1b326bda8e085cba59aa83b81251fd37cbf32b93
   desktop:
     mode: manual-only
     reason: npm-package-not-found


### PR DESCRIPTION
## 更新内容

将已收录的 `carlown__majia7-dsh-skin` 升级到 v0.3.6：

- **固定 commit**：`297cdd037e52f5a5c9e4c080a5dc8fd7d42fb730` → `1b326bda8e085cba59aa83b81251fd37cbf32b93`
- **version**：`0.3.4` → `0.3.6`

## 包含的皮肤仓库变更（自上次合并后）

1. `package.json` 元数据（repository / homepage / bugs）从上游 kingOfSoySauce 仓库指向 **本仓库** `Carlown/majia7-dsh-skin`（同名旧仓库不应再被指向）
2. README 新增「兼容性」小节，明确已验证 DSH Web 版本
3. `package.json` 新增 `engines.dsh: ">=0.1.1-rc.2 <0.2.0"`
4. README 修正皮肤市场覆盖说明：日常切走/关闭皮肤无害，**点"更新"才会用市场固定 commit 覆盖**（v0.3.4/v0.3.5 也附带小幅修正但本 PR 合并的是最新 yml 状态）
5. 删除「马加七皮肤 绑定思考等级」开关（v0.3.5）：滑块始终按当前思考档位渲染
6. 修复 loader 注册 id 必须等于包名（v0.3.4，0.3.3 启动失败的根因）

## 自动检查

- `npm run registry:check`：validated 225 skins
- yml schema：✓
- 固定 commit URL：`https://raw.githubusercontent.com/Carlown/majia7-dsh-skin/1b326bda8e085cba59aa83b81251fd37cbf32b93/docs/screenshots/...` 均可达

## 兼容性

DSH Web `0.1.1-rc.2` 实测通过；其他版本未验证（`engines.dsh` 标记 `>=0.1.1-rc.2 <0.2.0`）。

> 本 PR 不声称该皮肤获得 DSH 官方、安全团队或市场的新增背书，仅为已收录条目的版本与提交号更新。