### PR TITLE
feat(registry): add LiteGlass

### DIFF
--- a/registry/skins/mumuer1024__dsh-ui-liteglass.yml
+++ b/registry/skins/mumuer1024__dsh-ui-liteglass.yml
@@ -1,0 +1,41 @@
+id: mumuer1024.dsh-ui-liteglass
+name:
+  zh: LiteGlass
+  en: LiteGlass
+author: mumuer1024
+description: DeepSeek Harness 轻量级外观皮肤：自定义壁纸、玻璃质感面板与重点色；服务端持久化、多设备一致，不接管原生深浅色。
+repo: https://github.com/mumuer1024/dsh-ui-liteglass
+package: dsh-ui-liteglass
+rowId: ui-liteglass
+category: theme
+tags:
+  - wallpaper
+  - glass
+  - accent
+  - theme
+modes:
+  - light
+  - dark
+install:
+  target: github:mumuer1024/dsh-ui-liteglass#586943c25e559409d202ab1e572d4f7f848eb7a6
+  version: 0.1.0
+  commit: 586943c25e559409d202ab1e572d4f7f848eb7a6
+  allowBuild: dsh-ui-liteglass@https://codeload.github.com/mumuer1024/dsh-ui-liteglass/tar.gz/586943c25e559409d202ab1e572d4f7f848eb7a6
+compatibility:
+  dsh: 0.1.0-rc.7
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/mumuer1024/dsh-ui-liteglass/586943c25e559409d202ab1e572d4f7f848eb7a6/docs/screenshots/preview-light.webp
+  - https://raw.githubusercontent.com/mumuer1024/dsh-ui-liteglass/586943c25e559409d202ab1e572d4f7f848eb7a6/docs/screenshots/preview-dark.webp
+  - https://raw.githubusercontent.com/mumuer1024/dsh-ui-liteglass/586943c25e559409d202ab1e572d4f7f848eb7a6/docs/screenshots/settings-light.webp
+  - https://raw.githubusercontent.com/mumuer1024/dsh-ui-liteglass/586943c25e559409d202ab1e572d4f7f848eb7a6/docs/screenshots/settings-dark.webp
+license:
+  code: MIT
+  commercialUse: true
+featuredRank: 0
+starsSnapshot: 0
+releaseUpdatedAt: 2026-08-27T00:51:21Z
+metadataUpdatedAt: 2026-08-27T01:34:31Z
+starsUpdatedAt: 2026-08-27T01:34:31Z
+updatedAt: 2026-08-27T01:34:31Z


### PR DESCRIPTION
feat(registry): add LiteGlass

- 仓库: https://github.com/mumuer1024/dsh-ui-liteglass
- 子包: 无（单包）
- package: dsh-ui-liteglass ｜ rowId: ui-liteglass
- 版本: 0.1.0 ｜ commit: 586943c25e559409d202ab1e572d4f7f848eb7a6（固定 40 位）
- 许可证: MIT（commercialUse: true）
- 预览来源: 仓库内真实截图 docs/screenshots/*.webp（4 张，固定 commit raw URL，已探测 HTTP 200）
- 兼容性: dsh 0.1.0-rc.7（tested with），platform: web
- 自动检查: 本地 registry:check（validated 226 skins）+ smoke:submission（67 tests passed）通过；PR 提交后 CI 将再次校验 schema 与 id/package/rowId 唯一性
- 仍需人工确认的风险:
  - 仅在 DSH Web 0.1.0-rc.7 实际验证，未来 rc 接口可能变化
  - 未声明桌面端安装（desktop 字段省略，桌面 DSH 未测试）
  - 面板 backdrop-filter 模糊当前禁用（README 已知限制）
