### PR TITLE
feat(registry): add dsh-theme-aurum

### DIFF
--- a/registry/skins/fengb3__dsh-theme-aurum.yml
+++ b/registry/skins/fengb3__dsh-theme-aurum.yml
@@ -1,0 +1,39 @@
+id: fengb3.dsh-theme-aurum
+name:
+  zh: 鎏金 Aurum
+  en: Aurum
+author: fengb3
+description: DSH 鎏金主题：oklch 金粉双色层 + 24px 点阵画布 + 浮动卡片侧栏，会话栏/会话流/输入坞/工具卡全量接管（未知工具官方图标兜底）；theme.overrideTokens 常驻 {light,dark} 双色，priority:-1 遮蔽注册保留官方实现、停用即完整还原；零构建纯 loader 格式。
+repo: https://github.com/fengb3/dsh-theme-aurum
+package: dsh-theme-aurum
+rowId: theme-aurum
+category: theme
+tags:
+  - gold
+  - token-theme
+  - light-dark
+  - serif
+  - full-ui
+modes:
+  - light
+  - dark
+install:
+  target: github:fengb3/dsh-theme-aurum#5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2
+  version: 1.1.0
+  commit: 5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2
+compatibility:
+  dsh: ">=0.1.0-rc.6"
+  platform:
+    - web
+screenshots:
+  - https://raw.githubusercontent.com/fengb3/dsh-theme-aurum/5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2/screenshots/aurum-think-done-open.png
+  - https://raw.githubusercontent.com/fengb3/dsh-theme-aurum/5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2/screenshots/diag-appearance-after.png
+license:
+  code: MIT
+  commercialUse: true
+featuredRank: 0
+starsSnapshot: 0
+releaseUpdatedAt: 2026-08-28T05:00:00Z
+metadataUpdatedAt: 2026-08-28T05:00:00Z
+starsUpdatedAt: 2026-08-28T05:00:00Z
+updatedAt: 2026-08-28T05:00:00Z

--- a/registry/skins/fengb3__dsh-theme-aurum.yml
+++ b/registry/skins/fengb3__dsh-theme-aurum.yml
@@ -18,16 +18,16 @@ modes:
   - light
   - dark
 install:
-  target: github:fengb3/dsh-theme-aurum#5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2
+  target: github:fengb3/dsh-theme-aurum#a716a46cb55cdd8d05abdcea57e12b43b83a87fd
   version: 1.1.0
-  commit: 5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2
+  commit: a716a46cb55cdd8d05abdcea57e12b43b83a87fd
 compatibility:
   dsh: ">=0.1.0-rc.6"
   platform:
     - web
 screenshots:
-  - https://raw.githubusercontent.com/fengb3/dsh-theme-aurum/5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2/screenshots/aurum-think-done-open.png
-  - https://raw.githubusercontent.com/fengb3/dsh-theme-aurum/5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2/screenshots/diag-appearance-after.png
+  - https://raw.githubusercontent.com/fengb3/dsh-theme-aurum/a716a46cb55cdd8d05abdcea57e12b43b83a87fd/docs/previews/aurum-light-full.png
+  - https://raw.githubusercontent.com/fengb3/dsh-theme-aurum/a716a46cb55cdd8d05abdcea57e12b43b83a87fd/docs/previews/aurum-dark-settings.png
 license:
   code: MIT
   commercialUse: true


### PR DESCRIPTION
## 收录申请：dsh-theme-aurum（鎏金主题）

- **仓库**：https://github.com/fengb3/dsh-theme-aurum（单包，非 monorepo 子包）
- **包名 / rowId**：`dsh-theme-aurum` / `theme-aurum`（bundle patch 主 loader 行 `id: theme-aurum, name: dsh-theme-aurum`）
- **版本 / commit**：v1.1.0 @ `5ff8b1a06a30d537bdc7c0066b0a0ace90c276d2`（tag [v1.1.0](https://github.com/fengb3/dsh-theme-aurum/releases/tag/v1.1.0)）
- **许可证**：MIT（仓库含 [LICENSE](https://github.com/fengb3/dsh-theme-aurum/blob/main/LICENSE)，允许商用）
- **预览来源**：仓库 `screenshots/` 内真实界面截图，使用固定 commit 的 GitHub raw 地址（浅色整页 + 深色设置弹窗）
- **兼容性**：声明 DSH Web `>=0.1.0-rc.6`（基于 0.1.0-rc.6 官方 client API 开发，0.1.1-rc.2 实机全量 playwright 门禁通过；维护者可复核）
- **形态**：带 `dsh.bundle.patch` + `dsh.client.inject` 的完整插件，零构建纯 loader 格式，无 prepare 脚本（无需 allowBuilds）

### 自动检查

- `npm run registry:check`：✅ validated 227 skins（新增本条目后），catalog 未写入
- `git diff --name-only`：仅 `registry/skins/fengb3__dsh-theme-aurum.yml` 一个文件

### 仍需人工确认

- 兼容范围下限（`>=0.1.0-rc.6`）建议维护者在 rc.6 实机复核
- 深色整页主图暂缺，现以深色设置弹窗代替；后续版本会补
- 无 npm 包发布（desktop 场景如需可标 manual-only）
- 收录不等于安全认证，本条目不主张任何官方背书
