### PR TITLE
feat(registry): update 鎏金 Aurum to v1.2.0

### DIFF
--- a/registry/skins/fengb3__dsh-theme-aurum.yml
+++ b/registry/skins/fengb3__dsh-theme-aurum.yml
@@ -18,9 +18,9 @@ modes:
   - light
   - dark
 install:
-  target: github:fengb3/dsh-theme-aurum#a716a46cb55cdd8d05abdcea57e12b43b83a87fd
-  version: 1.1.0
-  commit: a716a46cb55cdd8d05abdcea57e12b43b83a87fd
+  target: github:fengb3/dsh-theme-aurum#7921baa8fd5658a077d6ad21ff7de4107ed15965
+  version: 1.2.0
+  commit: 7921baa8fd5658a077d6ad21ff7de4107ed15965
 compatibility:
   dsh: ">=0.1.0-rc.6"
   platform:


### PR DESCRIPTION
aurum v1.2.0:工作区菜单扩展点多插件共存(menu-extra list 槽)+ 注入行归流 reset。target/version/commit 三行更新,截图未变(旧 SHA 死引用仍有效)。上游:fengb3/dsh-theme-aurum@7921baa(tag v1.2.0)。