### PR TITLE
fix: harden Windows &path: subdirectory skin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ dsh plugin --profile web add "dsh-skin-market@latest"
 
 > 皮肤市场的安装、更新和卸载会调用 DSH 的 profile 插件管理器；当前 DSH 使用 `pnpm` 管理 profile 依赖。如果出现 `pnpm is not recognized`、`package manifest missing` 或 `allowBuilds` 相关报错，不必手动猜测 profile 状态。
 >
-> 含子目录路径的 GitHub 目标（`github:…#commit&path:/…`）请优先用市场页一键安装。Windows 上不要把这段 spec 交给 `dsh plugin add`：cmd.exe 会在 `&` 处截断。需要手动安装时用：
+> 含子目录路径的 GitHub 目标（`github:…#commit&path:/…`）请优先用市场页一键安装。市场安装结束后会校验 `node_modules` 中的包名是否与目录一致，避免 `&path:` 被截断时误把仓库根包装成成功。Windows 上不要把这段 spec 交给 `dsh plugin add`：cmd.exe 会在 `&` 处截断。需要手动安装时用：
 >
 > ```powershell
 > pnpm add "github:owner/repo#<commit>&path:/subdir" --dir $env:USERPROFILE\.dsh\profiles\web

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,4 +1,6 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { resolveProfileDir } from './profile.js';
 export function normalizedEnvironment(options) {
@@ -14,6 +16,85 @@ export function normalizedEnvironment(options) {
 }
 const PLUGIN_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
 export const winCmdShim = process.platform === 'win32';
+/**
+ * Bilingual guidance when `&path:` installs cannot start pnpm with shell:false.
+ * Common on Windows when PATH only has a `pnpm.cmd` shim.
+ */
+export const PNPM_DIRECT_SPAWN_ENOENT_HINT = '无法以 shell:false 启动真实 pnpm（常见原因：PATH 上只有 pnpm.cmd，而含 &path: 的安装不能再走 cmd 二次解析）。请确保存在 pnpm.exe、Corepack 激活的 pnpm，或可用 `node` 直接运行的 pnpm.cjs；可执行 `corepack enable pnpm` / 重装 pnpm 后重试。 / Could not spawn a real pnpm binary with shell:false (often PATH only has pnpm.cmd). Ensure pnpm.exe, Corepack-enabled pnpm, or node+pnpm.cjs is available — then retry (`corepack enable pnpm` or reinstall pnpm).';
+/**
+ * Directories that commonly hold pnpm when GUI/desktop launches omit shell PATH
+ * (same spirit as dsh-market toolSearchDirs).
+ */
+export function toolSearchDirs(platform = process.platform, env = process.env, home = homedir(), nodeDir = dirname(process.execPath)) {
+    const dirs = [];
+    const pnpmHome = (env.PNPM_HOME ?? '').trim();
+    if (pnpmHome !== '')
+        dirs.push(pnpmHome);
+    if (platform === 'win32') {
+        const local = (env.LOCALAPPDATA ?? '').trim();
+        const roaming = (env.APPDATA ?? '').trim();
+        if (local !== '')
+            dirs.push(join(local, 'pnpm'));
+        if (roaming !== '')
+            dirs.push(join(roaming, 'npm'));
+    }
+    else {
+        dirs.push('/opt/homebrew/bin', '/usr/local/bin', join(home, '.local', 'bin'));
+        dirs.push(join(home, 'Library', 'pnpm'), join(home, '.local', 'share', 'pnpm'));
+    }
+    dirs.push(nodeDir);
+    return [...new Set(dirs.filter(dir => dir.trim() !== ''))];
+}
+function pathEntries(env, platform) {
+    const separator = platform === 'win32' ? ';' : ':';
+    return (env.PATH ?? '').split(separator).filter(Boolean);
+}
+/**
+ * Resolve a real pnpm entrypoint for `shell: false` spawns (`&path:` installs).
+ * Prefer `pnpm.exe`, then `node` + absolute `pnpm.cjs` / Corepack script.
+ * Never returns a `.cmd`/`.bat` shim — those need the quoted cmd bridge and
+ * would reintroduce `&` truncation. Falls back to bare `pnpm` (may ENOENT on
+ * Windows when only a shim exists; callers map that to PNPM_DIRECT_SPAWN_ENOENT_HINT).
+ */
+export function resolvePnpmForDirectSpawn(options) {
+    const platform = options?.platform ?? process.platform;
+    const env = options?.env ?? process.env;
+    const home = options?.home ?? homedir();
+    const execPath = options?.execPath ?? process.execPath;
+    const search = [...toolSearchDirs(platform, env, home, dirname(execPath)), ...pathEntries(env, platform)];
+    if (platform === 'win32') {
+        for (const dir of search) {
+            const exe = join(dir, 'pnpm.exe');
+            if (existsSync(exe))
+                return { file: exe, prefix: [] };
+        }
+    }
+    else {
+        for (const dir of search) {
+            const bin = join(dir, 'pnpm');
+            if (existsSync(bin))
+                return { file: bin, prefix: [] };
+        }
+    }
+    const scriptRelatives = [
+        'pnpm.cjs',
+        join('bin', 'pnpm.cjs'),
+        join('node_modules', 'pnpm', 'bin', 'pnpm.cjs'),
+        join('node_modules', 'corepack', 'dist', 'pnpm.js'),
+        join('node_modules', 'corepack', 'dist', 'pnpm.cjs'),
+    ];
+    for (const dir of search) {
+        for (const relative of scriptRelatives) {
+            const script = join(dir, relative);
+            if (existsSync(script))
+                return { file: execPath, prefix: [script] };
+        }
+    }
+    return { file: 'pnpm', prefix: [] };
+}
+function isSpawnEnoent(error) {
+    return error.code === 'ENOENT' || /ENOENT/i.test(error.message ?? '');
+}
 function dshInvocation() {
     const entry = process.argv[1];
     if (entry !== undefined && /[\\/](?:bin\.(?:js|ts)|dsh)$/.test(entry)) {
@@ -33,11 +114,21 @@ function dshInvocation() {
 export function pluginProcess(profile, args) {
     if (args.some(arg => arg.includes('&'))) {
         const profileDir = resolveProfileDir(profile);
+        // Keep `&path:` as one argv element. Do not re-enter cmd.exe: a second
+        // parse can truncate left-of-`&` and pnpm still exits 0 with the repo
+        // root package. Resolve pnpm.exe or node→pnpm.cjs; bare pnpm.cmd is not
+        // enough for shell:false. Non-`&` / provisioning still use the quoted
+        // cmd bridge for .cmd shims via ensurePnpmAvailable / dshInvocation.
+        // Windows cannot spawn pnpm.cmd with shell:false; resolve pnpm.exe /
+        // node+pnpm.cjs. Unix can spawn the PATH `pnpm` script directly.
+        const pnpm = process.platform === 'win32' ? resolvePnpmForDirectSpawn() : { file: 'pnpm', prefix: [] };
+        const pluginArgs = args.includes('--dir') ? [...args] : [...args, '--dir', profileDir];
         return {
-            file: 'pnpm',
-            argv: args.includes('--dir') ? [...args] : [...args, '--dir', profileDir],
+            file: pnpm.file,
+            argv: [...pnpm.prefix, ...pluginArgs],
             cwd: profileDir,
-            viaShell: winCmdShim,
+            viaShell: false,
+            directPnpm: true,
         };
     }
     const invocation = dshInvocation();
@@ -90,14 +181,13 @@ function stoppedBeforeStart(options) {
 }
 function commandEnvironment(options) {
     const env = { ...process.env, ...normalizedEnvironment(options), CI: 'true' };
-    if (process.platform !== 'win32') {
-        const parts = (env.PATH ?? '').split(':').filter(Boolean);
-        for (const value of ['/opt/homebrew/bin', '/usr/local/bin', join(process.env.HOME ?? '', '.local', 'bin')]) {
-            if (value !== '' && !parts.includes(value))
-                parts.push(value);
-        }
-        env.PATH = parts.join(':');
+    const separator = process.platform === 'win32' ? ';' : ':';
+    const parts = (env.PATH ?? '').split(separator).filter(Boolean);
+    for (const value of toolSearchDirs()) {
+        if (value !== '' && !parts.includes(value))
+            parts.push(value);
     }
+    env.PATH = parts.join(separator);
     return env;
 }
 function runProcess(invocation, defaultTimeoutMs, options) {
@@ -174,7 +264,13 @@ function runProcess(invocation, defaultTimeoutMs, options) {
         if (options?.signal?.aborted === true)
             abort();
         const timer = setTimeout(() => { timedOut = true; kill('SIGKILL'); }, commandTimeout(options, defaultTimeoutMs));
-        child.on('error', error => { stderr += error.message; });
+        child.on('error', error => {
+            const err = error;
+            if (invocation.directPnpm === true && isSpawnEnoent(err))
+                stderr += PNPM_DIRECT_SPAWN_ENOENT_HINT;
+            else
+                stderr += err.message;
+        });
         child.on('close', exitCode => {
             closed = true;
             clearTimeout(timer);
@@ -321,6 +417,13 @@ async function runDesktopOperation(start, options) {
         clearTimeout(timer);
     }
 }
+/**
+ * Desktop host runner. Managed npm installs stay on the host `installPlugin`
+ * / `runPlugin` path and must not be rewritten through `pluginProcess`.
+ * GitHub `&path:` one-click harden (direct pnpm + shell:false) applies to the
+ * DSH/web `runPluginCli` path; Desktop skins that need `&path:` are typically
+ * `manual-only` / not Desktop-managed.
+ */
 export function desktopRunner(service, profileDir) {
     const runner = (_profile, args, options) => runDesktopOperation(signal => service.runPlugin(args, profileDir, signal), options);
     runner.hostKind = 'desktop';
@@ -344,6 +447,10 @@ export function commandError(result) {
     const output = `${result.stdout}\n${result.stderr}`.trim();
     if (/\[23\].*aborted due to timeout|TimeoutError: The operation was aborted due to timeout/is.test(output)) {
         return 'GitHub 插件下载超时；安装包较大或当前网络较慢，请检查网络后重试';
+    }
+    // Direct `&path:` pnpm spawn: surface actionable guidance instead of raw Node ENOENT.
+    if (output.includes(PNPM_DIRECT_SPAWN_ENOENT_HINT) || /spawn\s+\S*pnpm\S*.*ENOENT/i.test(output)) {
+        return PNPM_DIRECT_SPAWN_ENOENT_HINT;
     }
     return (output || `plugin command exited ${String(result.exitCode)}`).slice(-1600);
 }

--- a/lib/lifecycle.js
+++ b/lib/lifecycle.js
@@ -674,6 +674,9 @@ export class SkinLifecycle {
         if (operation.kind !== 'migrate')
             await this.installCompanions(skin, operation, state);
         await this.run(['add', prefetched.target, '--prefer-offline', ...(isNpmInstallTarget(skin, prefetched.target) ? ['--save-exact'] : [])], operation);
+        const liveValidation = validateInstalledSkin(this.options.profileDir, skin);
+        if (!liveValidation.ok)
+            throw new Error(liveValidation.reason);
         this.claimManagedLoaders(state, skin, prefetched.loaderRows, beforeRows);
     }
     async installCompanions(skin, operation, state) {
@@ -683,6 +686,12 @@ export class SkinLifecycle {
             const linked = state.managedCompanions?.[companion.package];
             if (existingSpec === undefined || (linked?.installedByMarket === true && companionNeedsInstall(this.options.profileDir, companion))) {
                 await this.run(['add', companion.target, '--prefer-offline'], operation);
+                // Same identity guard as the main skin: exit 0 + truncated `&path:` can
+                // materialize the monorepo root under a different dep key. Refuse before
+                // claiming market ownership / registration.
+                const companionValidation = validateInstalledSkin(this.options.profileDir, companionAsSkin(skin, companion));
+                if (!companionValidation.ok)
+                    throw new Error(companionValidation.reason);
                 this.claimManagedCompanion(state, companion.package, skin.id, true);
             }
             else if (linked !== undefined) {
@@ -814,17 +823,19 @@ export class SkinLifecycle {
                 this.preparePrefetchDirectory(directory, this.prefetchBuildApprovals(skin, operation, target));
                 await this.run(['add', target, '--dir', directory, '--ignore-scripts', '--config.auto-install-peers=false'], operation);
             }
-            const packageDirectory = join(directory, 'node_modules', ...skin.package.split('/'));
+            // Exit 0 alone is not success: a truncated `&path:` target installs the
+            // repo root under a different dependency key. Refuse before live profile add.
+            const validation = validateInstalledSkin(directory, skin);
+            if (!validation.ok)
+                throw new Error(validation.reason);
             if (isNpmInstallTarget(skin, target)) {
                 if (readDependencies(directory)[skin.package] !== skin.install.npm?.version) {
                     throw new Error('下载的 npm 依赖未记录目录固定版本，已停止安装');
                 }
-                const validation = validateInstalledSkin(directory, skin);
-                if (!validation.ok)
-                    throw new Error(validation.reason);
                 if (validation.version !== skin.install.version)
                     throw new Error('下载的 npm 包版本与目录固定版本不一致');
             }
+            const packageDirectory = join(directory, 'node_modules', ...skin.package.split('/'));
             const packageRows = packageLoaderOwnershipAt(packageDirectory, skin.package);
             if (packageRows.hasBundle) {
                 const primaryRows = packageRows.rows.filter(row => row.name === skin.package);

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -205,21 +205,28 @@ function validateInstalledNpmSource(profileDir, skin, manifest) {
     }
     return null;
 }
+/** Hint when a GitHub subdirectory install may have lost `&path:` in shell/cmd. */
+function pathSelectorTruncationHint(skin) {
+    if (!skin.install.target.includes('&path:'))
+        return '';
+    return '。检测到含 &path: 的子目录选择器在安装过程中可能被截断（argv 不完整），因而装上了仓库根包而非目录子包；请确认 pnpm 以真实二进制、shell:false 收到完整目标后重试';
+}
 export function validateInstalledSkin(profileDir, skin) {
+    const hint = pathSelectorTruncationHint(skin);
     const manifest = packageManifest(profileDir, skin.package);
     if (manifest === null)
         return {
             ok: false,
             repairable: true,
-            reason: `installed package manifest missing for ${skin.package}; the plugin command returned without materializing the reviewed package`,
+            reason: `installed package manifest missing for ${skin.package}; the plugin command returned without materializing the reviewed package${hint}`,
         };
     const manifestName = typeof manifest.name === 'string' ? manifest.name : undefined;
     if (manifestName === undefined)
-        return { ok: false, reason: `installed package name missing; expected ${skin.package}` };
+        return { ok: false, reason: `installed package name missing; expected ${skin.package}${hint}` };
     if (manifestName !== skin.package)
         return {
             ok: false,
-            reason: `installed package name mismatch; expected ${skin.package}, found ${manifestName}`,
+            reason: `installed package name mismatch; expected ${skin.package}, found ${manifestName}${hint}`,
         };
     const version = typeof manifest.version === 'string' ? manifest.version : undefined;
     if (version === undefined)

--- a/lib/types/commands.d.ts
+++ b/lib/types/commands.d.ts
@@ -29,11 +29,40 @@ export interface PluginRunner {
 }
 export declare function normalizedEnvironment(options?: CommandOptions): NodeJS.ProcessEnv | undefined;
 export declare const winCmdShim: boolean;
+/**
+ * Bilingual guidance when `&path:` installs cannot start pnpm with shell:false.
+ * Common on Windows when PATH only has a `pnpm.cmd` shim.
+ */
+export declare const PNPM_DIRECT_SPAWN_ENOENT_HINT = "\u65E0\u6CD5\u4EE5 shell:false \u542F\u52A8\u771F\u5B9E pnpm\uFF08\u5E38\u89C1\u539F\u56E0\uFF1APATH \u4E0A\u53EA\u6709 pnpm.cmd\uFF0C\u800C\u542B &path: \u7684\u5B89\u88C5\u4E0D\u80FD\u518D\u8D70 cmd \u4E8C\u6B21\u89E3\u6790\uFF09\u3002\u8BF7\u786E\u4FDD\u5B58\u5728 pnpm.exe\u3001Corepack \u6FC0\u6D3B\u7684 pnpm\uFF0C\u6216\u53EF\u7528 `node` \u76F4\u63A5\u8FD0\u884C\u7684 pnpm.cjs\uFF1B\u53EF\u6267\u884C `corepack enable pnpm` / \u91CD\u88C5 pnpm \u540E\u91CD\u8BD5\u3002 / Could not spawn a real pnpm binary with shell:false (often PATH only has pnpm.cmd). Ensure pnpm.exe, Corepack-enabled pnpm, or node+pnpm.cjs is available \u2014 then retry (`corepack enable pnpm` or reinstall pnpm).";
+/**
+ * Directories that commonly hold pnpm when GUI/desktop launches omit shell PATH
+ * (same spirit as dsh-market toolSearchDirs).
+ */
+export declare function toolSearchDirs(platform?: string, env?: NodeJS.ProcessEnv, home?: string, nodeDir?: string): string[];
+export interface PnpmDirectSpawn {
+    file: string;
+    prefix: string[];
+}
+/**
+ * Resolve a real pnpm entrypoint for `shell: false` spawns (`&path:` installs).
+ * Prefer `pnpm.exe`, then `node` + absolute `pnpm.cjs` / Corepack script.
+ * Never returns a `.cmd`/`.bat` shim — those need the quoted cmd bridge and
+ * would reintroduce `&` truncation. Falls back to bare `pnpm` (may ENOENT on
+ * Windows when only a shim exists; callers map that to PNPM_DIRECT_SPAWN_ENOENT_HINT).
+ */
+export declare function resolvePnpmForDirectSpawn(options?: {
+    platform?: string;
+    env?: NodeJS.ProcessEnv;
+    home?: string;
+    execPath?: string;
+}): PnpmDirectSpawn;
 export interface PluginProcess {
     file: string;
     argv: string[];
     cwd?: string;
     viaShell: boolean;
+    /** True when spawning pnpm directly for `&`-bearing argv (shell:false). */
+    directPnpm?: boolean;
 }
 /**
  * Choose how to run a profile plugin command.
@@ -80,5 +109,12 @@ export interface DesktopPnpmLike {
         cancel(): void;
     }>;
 }
+/**
+ * Desktop host runner. Managed npm installs stay on the host `installPlugin`
+ * / `runPlugin` path and must not be rewritten through `pluginProcess`.
+ * GitHub `&path:` one-click harden (direct pnpm + shell:false) applies to the
+ * DSH/web `runPluginCli` path; Desktop skins that need `&path:` are typically
+ * `manual-only` / not Desktop-managed.
+ */
 export declare function desktopRunner(service: DesktopPnpmLike, profileDir: string): PluginRunner;
 export declare function commandError(result: CommandResult): string;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { resolveProfileDir } from './profile.ts'
 import type { MarketHostKind } from './types.ts'
@@ -48,6 +50,101 @@ export function normalizedEnvironment(options?: CommandOptions): NodeJS.ProcessE
 const PLUGIN_COMMAND_TIMEOUT_MS = 10 * 60 * 1000
 export const winCmdShim = process.platform === 'win32'
 
+/**
+ * Bilingual guidance when `&path:` installs cannot start pnpm with shell:false.
+ * Common on Windows when PATH only has a `pnpm.cmd` shim.
+ */
+export const PNPM_DIRECT_SPAWN_ENOENT_HINT =
+  '无法以 shell:false 启动真实 pnpm（常见原因：PATH 上只有 pnpm.cmd，而含 &path: 的安装不能再走 cmd 二次解析）。请确保存在 pnpm.exe、Corepack 激活的 pnpm，或可用 `node` 直接运行的 pnpm.cjs；可执行 `corepack enable pnpm` / 重装 pnpm 后重试。 / Could not spawn a real pnpm binary with shell:false (often PATH only has pnpm.cmd). Ensure pnpm.exe, Corepack-enabled pnpm, or node+pnpm.cjs is available — then retry (`corepack enable pnpm` or reinstall pnpm).'
+
+/**
+ * Directories that commonly hold pnpm when GUI/desktop launches omit shell PATH
+ * (same spirit as dsh-market toolSearchDirs).
+ */
+export function toolSearchDirs(
+  platform: string = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+  nodeDir: string = dirname(process.execPath),
+): string[] {
+  const dirs: string[] = []
+  const pnpmHome = (env.PNPM_HOME ?? '').trim()
+  if (pnpmHome !== '') dirs.push(pnpmHome)
+  if (platform === 'win32') {
+    const local = (env.LOCALAPPDATA ?? '').trim()
+    const roaming = (env.APPDATA ?? '').trim()
+    if (local !== '') dirs.push(join(local, 'pnpm'))
+    if (roaming !== '') dirs.push(join(roaming, 'npm'))
+  } else {
+    dirs.push('/opt/homebrew/bin', '/usr/local/bin', join(home, '.local', 'bin'))
+    dirs.push(join(home, 'Library', 'pnpm'), join(home, '.local', 'share', 'pnpm'))
+  }
+  dirs.push(nodeDir)
+  return [...new Set(dirs.filter(dir => dir.trim() !== ''))]
+}
+
+function pathEntries(env: NodeJS.ProcessEnv, platform: string): string[] {
+  const separator = platform === 'win32' ? ';' : ':'
+  return (env.PATH ?? '').split(separator).filter(Boolean)
+}
+
+export interface PnpmDirectSpawn {
+  file: string
+  prefix: string[]
+}
+
+/**
+ * Resolve a real pnpm entrypoint for `shell: false` spawns (`&path:` installs).
+ * Prefer `pnpm.exe`, then `node` + absolute `pnpm.cjs` / Corepack script.
+ * Never returns a `.cmd`/`.bat` shim — those need the quoted cmd bridge and
+ * would reintroduce `&` truncation. Falls back to bare `pnpm` (may ENOENT on
+ * Windows when only a shim exists; callers map that to PNPM_DIRECT_SPAWN_ENOENT_HINT).
+ */
+export function resolvePnpmForDirectSpawn(options?: {
+  platform?: string
+  env?: NodeJS.ProcessEnv
+  home?: string
+  execPath?: string
+}): PnpmDirectSpawn {
+  const platform = options?.platform ?? process.platform
+  const env = options?.env ?? process.env
+  const home = options?.home ?? homedir()
+  const execPath = options?.execPath ?? process.execPath
+  const search = [...toolSearchDirs(platform, env, home, dirname(execPath)), ...pathEntries(env, platform)]
+
+  if (platform === 'win32') {
+    for (const dir of search) {
+      const exe = join(dir, 'pnpm.exe')
+      if (existsSync(exe)) return { file: exe, prefix: [] }
+    }
+  } else {
+    for (const dir of search) {
+      const bin = join(dir, 'pnpm')
+      if (existsSync(bin)) return { file: bin, prefix: [] }
+    }
+  }
+
+  const scriptRelatives = [
+    'pnpm.cjs',
+    join('bin', 'pnpm.cjs'),
+    join('node_modules', 'pnpm', 'bin', 'pnpm.cjs'),
+    join('node_modules', 'corepack', 'dist', 'pnpm.js'),
+    join('node_modules', 'corepack', 'dist', 'pnpm.cjs'),
+  ]
+  for (const dir of search) {
+    for (const relative of scriptRelatives) {
+      const script = join(dir, relative)
+      if (existsSync(script)) return { file: execPath, prefix: [script] }
+    }
+  }
+
+  return { file: 'pnpm', prefix: [] }
+}
+
+function isSpawnEnoent(error: NodeJS.ErrnoException): boolean {
+  return error.code === 'ENOENT' || /ENOENT/i.test(error.message ?? '')
+}
+
 function dshInvocation(): { file: string; prefix: string[]; cwd?: string; viaShell: boolean } {
   const entry = process.argv[1]
   if (entry !== undefined && /[\\/](?:bin\.(?:js|ts)|dsh)$/.test(entry)) {
@@ -62,6 +159,8 @@ export interface PluginProcess {
   argv: string[]
   cwd?: string
   viaShell: boolean
+  /** True when spawning pnpm directly for `&`-bearing argv (shell:false). */
+  directPnpm?: boolean
 }
 
 /**
@@ -75,11 +174,21 @@ export interface PluginProcess {
 export function pluginProcess(profile: string, args: readonly string[]): PluginProcess {
   if (args.some(arg => arg.includes('&'))) {
     const profileDir = resolveProfileDir(profile)
+    // Keep `&path:` as one argv element. Do not re-enter cmd.exe: a second
+    // parse can truncate left-of-`&` and pnpm still exits 0 with the repo
+    // root package. Resolve pnpm.exe or node→pnpm.cjs; bare pnpm.cmd is not
+    // enough for shell:false. Non-`&` / provisioning still use the quoted
+    // cmd bridge for .cmd shims via ensurePnpmAvailable / dshInvocation.
+    // Windows cannot spawn pnpm.cmd with shell:false; resolve pnpm.exe /
+    // node+pnpm.cjs. Unix can spawn the PATH `pnpm` script directly.
+    const pnpm = process.platform === 'win32' ? resolvePnpmForDirectSpawn() : { file: 'pnpm', prefix: [] as string[] }
+    const pluginArgs = args.includes('--dir') ? [...args] : [...args, '--dir', profileDir]
     return {
-      file: 'pnpm',
-      argv: args.includes('--dir') ? [...args] : [...args, '--dir', profileDir],
+      file: pnpm.file,
+      argv: [...pnpm.prefix, ...pluginArgs],
       cwd: profileDir,
-      viaShell: winCmdShim,
+      viaShell: false,
+      directPnpm: true,
     }
   }
   const invocation = dshInvocation()
@@ -140,13 +249,12 @@ function stoppedBeforeStart(options?: CommandOptions): CommandResult | undefined
 
 function commandEnvironment(options?: CommandOptions): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, ...normalizedEnvironment(options), CI: 'true' }
-  if (process.platform !== 'win32') {
-    const parts = (env.PATH ?? '').split(':').filter(Boolean)
-    for (const value of ['/opt/homebrew/bin', '/usr/local/bin', join(process.env.HOME ?? '', '.local', 'bin')]) {
-      if (value !== '' && !parts.includes(value)) parts.push(value)
-    }
-    env.PATH = parts.join(':')
+  const separator = process.platform === 'win32' ? ';' : ':'
+  const parts = (env.PATH ?? '').split(separator).filter(Boolean)
+  for (const value of toolSearchDirs()) {
+    if (value !== '' && !parts.includes(value)) parts.push(value)
   }
+  env.PATH = parts.join(separator)
   return env
 }
 
@@ -206,7 +314,11 @@ function runProcess(invocation: PluginProcess, defaultTimeoutMs: number, options
     options?.signal?.addEventListener('abort', abort, { once: true })
     if (options?.signal?.aborted === true) abort()
     const timer = setTimeout(() => { timedOut = true; kill('SIGKILL') }, commandTimeout(options, defaultTimeoutMs))
-    child.on('error', error => { stderr += error.message })
+    child.on('error', error => {
+      const err = error as NodeJS.ErrnoException
+      if (invocation.directPnpm === true && isSpawnEnoent(err)) stderr += PNPM_DIRECT_SPAWN_ENOENT_HINT
+      else stderr += err.message
+    })
     child.on('close', exitCode => {
       closed = true
       clearTimeout(timer)
@@ -383,6 +495,13 @@ async function runDesktopOperation(
   }
 }
 
+/**
+ * Desktop host runner. Managed npm installs stay on the host `installPlugin`
+ * / `runPlugin` path and must not be rewritten through `pluginProcess`.
+ * GitHub `&path:` one-click harden (direct pnpm + shell:false) applies to the
+ * DSH/web `runPluginCli` path; Desktop skins that need `&path:` are typically
+ * `manual-only` / not Desktop-managed.
+ */
 export function desktopRunner(service: DesktopPnpmLike, profileDir: string): PluginRunner {
   const runner: PluginRunner = (_profile, args, options) => runDesktopOperation(
     signal => service.runPlugin(args, profileDir, signal),
@@ -411,6 +530,10 @@ export function commandError(result: CommandResult): string {
   const output = `${result.stdout}\n${result.stderr}`.trim()
   if (/\[23\].*aborted due to timeout|TimeoutError: The operation was aborted due to timeout/is.test(output)) {
     return 'GitHub 插件下载超时；安装包较大或当前网络较慢，请检查网络后重试'
+  }
+  // Direct `&path:` pnpm spawn: surface actionable guidance instead of raw Node ENOENT.
+  if (output.includes(PNPM_DIRECT_SPAWN_ENOENT_HINT) || /spawn\s+\S*pnpm\S*.*ENOENT/i.test(output)) {
+    return PNPM_DIRECT_SPAWN_ENOENT_HINT
   }
   return (output || `plugin command exited ${String(result.exitCode)}`).slice(-1600)
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -728,6 +728,8 @@ export class SkinLifecycle {
     // upgrades remain part of the separate ordinary Update operation.
     if (operation.kind !== 'migrate') await this.installCompanions(skin, operation, state)
     await this.run(['add', prefetched.target, '--prefer-offline', ...(isNpmInstallTarget(skin, prefetched.target) ? ['--save-exact'] : [])], operation)
+    const liveValidation = validateInstalledSkin(this.options.profileDir, skin)
+    if (!liveValidation.ok) throw new Error(liveValidation.reason)
     this.claimManagedLoaders(state, skin, prefetched.loaderRows, beforeRows)
   }
 
@@ -738,6 +740,11 @@ export class SkinLifecycle {
       const linked = state.managedCompanions?.[companion.package]
       if (existingSpec === undefined || (linked?.installedByMarket === true && companionNeedsInstall(this.options.profileDir, companion))) {
         await this.run(['add', companion.target, '--prefer-offline'], operation)
+        // Same identity guard as the main skin: exit 0 + truncated `&path:` can
+        // materialize the monorepo root under a different dep key. Refuse before
+        // claiming market ownership / registration.
+        const companionValidation = validateInstalledSkin(this.options.profileDir, companionAsSkin(skin, companion))
+        if (!companionValidation.ok) throw new Error(companionValidation.reason)
         this.claimManagedCompanion(state, companion.package, skin.id, true)
       } else if (linked !== undefined) {
         // An existing ownership receipt grants activation linkage, while its
@@ -867,15 +874,17 @@ export class SkinLifecycle {
         this.preparePrefetchDirectory(directory, this.prefetchBuildApprovals(skin, operation, target))
         await this.run(['add', target, '--dir', directory, '--ignore-scripts', '--config.auto-install-peers=false'], operation)
       }
-      const packageDirectory = join(directory, 'node_modules', ...skin.package.split('/'))
+      // Exit 0 alone is not success: a truncated `&path:` target installs the
+      // repo root under a different dependency key. Refuse before live profile add.
+      const validation = validateInstalledSkin(directory, skin)
+      if (!validation.ok) throw new Error(validation.reason)
       if (isNpmInstallTarget(skin, target)) {
         if (readDependencies(directory)[skin.package] !== skin.install.npm?.version) {
           throw new Error('下载的 npm 依赖未记录目录固定版本，已停止安装')
         }
-        const validation = validateInstalledSkin(directory, skin)
-        if (!validation.ok) throw new Error(validation.reason)
         if (validation.version !== skin.install.version) throw new Error('下载的 npm 包版本与目录固定版本不一致')
       }
+      const packageDirectory = join(directory, 'node_modules', ...skin.package.split('/'))
       const packageRows = packageLoaderOwnershipAt(packageDirectory, skin.package)
       if (packageRows.hasBundle) {
         const primaryRows = packageRows.rows.filter(row => row.name === skin.package)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -194,18 +194,25 @@ function validateInstalledNpmSource(profileDir: string, skin: SkinEntry, manifes
   return null
 }
 
+/** Hint when a GitHub subdirectory install may have lost `&path:` in shell/cmd. */
+function pathSelectorTruncationHint(skin: SkinEntry): string {
+  if (!skin.install.target.includes('&path:')) return ''
+  return '。检测到含 &path: 的子目录选择器在安装过程中可能被截断（argv 不完整），因而装上了仓库根包而非目录子包；请确认 pnpm 以真实二进制、shell:false 收到完整目标后重试'
+}
+
 export function validateInstalledSkin(profileDir: string, skin: SkinEntry): { ok: boolean; reason?: string; version?: string; repairable?: boolean } {
+  const hint = pathSelectorTruncationHint(skin)
   const manifest = packageManifest(profileDir, skin.package)
   if (manifest === null) return {
     ok: false,
     repairable: true,
-    reason: `installed package manifest missing for ${skin.package}; the plugin command returned without materializing the reviewed package`,
+    reason: `installed package manifest missing for ${skin.package}; the plugin command returned without materializing the reviewed package${hint}`,
   }
   const manifestName = typeof manifest.name === 'string' ? manifest.name : undefined
-  if (manifestName === undefined) return { ok: false, reason: `installed package name missing; expected ${skin.package}` }
+  if (manifestName === undefined) return { ok: false, reason: `installed package name missing; expected ${skin.package}${hint}` }
   if (manifestName !== skin.package) return {
     ok: false,
-    reason: `installed package name mismatch; expected ${skin.package}, found ${manifestName}`,
+    reason: `installed package name mismatch; expected ${skin.package}, found ${manifestName}${hint}`,
   }
   const version = typeof manifest.version === 'string' ? manifest.version : undefined
   if (version === undefined) return { ok: false, reason: `installed package version missing for ${skin.package}` }

--- a/tests/commands-process.spec.ts
+++ b/tests/commands-process.spec.ts
@@ -120,4 +120,85 @@ describe('plugin process termination', () => {
     expect(processBoundary.spawn).toHaveBeenCalledTimes(2)
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('preserves &path: targets by spawning pnpm without the Windows cmd bridge', async () => {
+    usePlatform('win32')
+    const { runPluginCli } = await import('../src/commands.ts')
+    const target = 'github:owner/repo#' + 'a'.repeat(40) + '&path:/maid-atelier'
+    const pending = runPluginCli('web', ['add', target, '--prefer-offline'])
+    expect(processBoundary.spawn).toHaveBeenCalledTimes(1)
+    const [file, argv, options] = processBoundary.spawn.mock.calls[0]!
+    // No pnpm.exe in the fake win32 env → bare name fallback; still shell:false.
+    expect(file).toBe('pnpm')
+    expect(file).not.toBe('cmd.exe')
+    expect(argv).toEqual(expect.arrayContaining([target]))
+    expect((argv as string[]).filter(arg => arg.includes('&'))).toEqual([target])
+    expect(options).toMatchObject({ shell: false })
+    child.emit('close', 0)
+    await expect(pending).resolves.toMatchObject({ exitCode: 0, timedOut: false })
+  })
+
+  it('keeps non-& installs on the Windows cmd.exe bridge', async () => {
+    usePlatform('win32')
+    const { runPluginCli } = await import('../src/commands.ts')
+    const pending = runPluginCli('web', ['add', 'example-skin@1.0.0'])
+    expect(processBoundary.spawn).toHaveBeenCalledTimes(1)
+    const [file, argv, options] = processBoundary.spawn.mock.calls[0]!
+    expect(file).toBe(process.env.ComSpec ?? 'cmd.exe')
+    expect(argv[0]).toBe('/d')
+    expect(argv[1]).toBe('/s')
+    expect(argv[2]).toBe('/c')
+    expect(String(argv[3])).toContain('example-skin@1.0.0')
+    expect(String(argv[3])).not.toContain('&path:')
+    expect(options).toMatchObject({ shell: false, windowsVerbatimArguments: true })
+    child.emit('close', 0)
+    await expect(pending).resolves.toMatchObject({ exitCode: 0 })
+  })
+
+  it('maps &path: spawn ENOENT to the bilingual pnpm-binary hint', async () => {
+    usePlatform('win32')
+    const { runPluginCli, PNPM_DIRECT_SPAWN_ENOENT_HINT } = await import('../src/commands.ts')
+    const target = 'github:owner/repo#' + 'a'.repeat(40) + '&path:/maid-atelier'
+    const pending = runPluginCli('web', ['add', target])
+    const err = Object.assign(new Error('spawn pnpm ENOENT'), { code: 'ENOENT' })
+    child.emit('error', err)
+    child.emit('close', null)
+    await expect(pending).resolves.toMatchObject({
+      exitCode: null,
+      stderr: PNPM_DIRECT_SPAWN_ENOENT_HINT,
+    })
+  })
+
+  it('spawns resolved pnpm.exe with shell:false when present on win32', async () => {
+    usePlatform('win32')
+    const { mkdirSync, rmSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const root = join(tmpdir(), 'dsh-pnpm-exe-spawn')
+    rmSync(root, { recursive: true, force: true })
+    mkdirSync(root, { recursive: true })
+    const exe = join(root, 'pnpm.exe')
+    writeFileSync(exe, '')
+    const previous = process.env.PNPM_HOME
+    process.env.PNPM_HOME = root
+    try {
+      vi.resetModules()
+      const { runPluginCli } = await import('../src/commands.ts')
+      const target = 'github:owner/repo#' + 'b'.repeat(40) + '&path:/sub'
+      child = fakeChild()
+      processBoundary.spawn.mockImplementation((file: string) => file === 'taskkill' ? cleanup : child)
+      const pending = runPluginCli('web', ['add', target])
+      const [file, argv, options] = processBoundary.spawn.mock.calls[0]!
+      expect(file).toBe(exe)
+      expect(file).not.toBe('cmd.exe')
+      expect(argv).toEqual(expect.arrayContaining([target]))
+      expect(options).toMatchObject({ shell: false })
+      child.emit('close', 0)
+      await expect(pending).resolves.toMatchObject({ exitCode: 0 })
+    } finally {
+      if (previous === undefined) delete process.env.PNPM_HOME
+      else process.env.PNPM_HOME = previous
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -1,6 +1,8 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 import { describe, expect, it, vi } from 'vitest'
-import { cmdCommandLine, commandError, createPnpmProvisioner, desktopRunner, normalizedEnvironment, pluginProcess, quoteCmdArg, type CommandResult, type DesktopPnpmLike } from '../src/commands.ts'
+import { cmdCommandLine, commandError, createPnpmProvisioner, desktopRunner, normalizedEnvironment, pluginProcess, PNPM_DIRECT_SPAWN_ENOENT_HINT, quoteCmdArg, resolvePnpmForDirectSpawn, toolSearchDirs, type CommandResult, type DesktopPnpmLike } from '../src/commands.ts'
 
 describe('Windows command shim quoting', () => {
   it('quotes cmd metacharacters as one argument', () => {
@@ -14,9 +16,65 @@ describe('Windows command shim quoting', () => {
     const target = 'github:owner/repo#' + 'a'.repeat(40) + '&path:/maid-atelier'
     const process = pluginProcess('web', ['add', target, '--prefer-offline'])
     expect(process.file).toBe('pnpm')
+    expect(process.viaShell).toBe(false)
+    expect(process.directPnpm).toBe(true)
     expect(process.argv).toEqual(['add', target, '--prefer-offline', '--dir', process.cwd])
     expect(process.argv.filter(arg => arg.includes('&'))).toEqual([target])
-    expect(pluginProcess('web', ['add', 'dskin@1.0.0']).argv).toContain('plugin')
+    const ordinary = pluginProcess('web', ['add', 'dskin@1.0.0'])
+    expect(ordinary.argv).toContain('plugin')
+    expect(ordinary.directPnpm).toBeUndefined()
+  })
+
+  it('resolves pnpm.exe or node+pnpm.cjs for Windows direct spawns', () => {
+    const root = join('/tmp', 'dsh-pnpm-resolve-fixture')
+    rmSync(root, { recursive: true, force: true })
+    mkdirSync(join(root, 'pnpm-home'), { recursive: true })
+    writeFileSync(join(root, 'pnpm-home', 'pnpm.exe'), '')
+    expect(resolvePnpmForDirectSpawn({
+      platform: 'win32',
+      env: { PNPM_HOME: join(root, 'pnpm-home'), PATH: '', LOCALAPPDATA: '', APPDATA: '' },
+      home: root,
+      execPath: join(root, 'node.exe'),
+    })).toEqual({ file: join(root, 'pnpm-home', 'pnpm.exe'), prefix: [] })
+
+    rmSync(root, { recursive: true, force: true })
+    mkdirSync(join(root, 'node_modules', 'pnpm', 'bin'), { recursive: true })
+    const cjs = join(root, 'node_modules', 'pnpm', 'bin', 'pnpm.cjs')
+    writeFileSync(cjs, '')
+    const execPath = join(root, 'node.exe')
+    expect(resolvePnpmForDirectSpawn({
+      platform: 'win32',
+      env: { PATH: root, PNPM_HOME: '', LOCALAPPDATA: '', APPDATA: '' },
+      home: root,
+      execPath,
+    })).toEqual({ file: execPath, prefix: [cjs] })
+
+    // .cmd alone must not be chosen for shell:false
+    rmSync(root, { recursive: true, force: true })
+    mkdirSync(join(root, 'npm'), { recursive: true })
+    writeFileSync(join(root, 'npm', 'pnpm.cmd'), '')
+    expect(resolvePnpmForDirectSpawn({
+      platform: 'win32',
+      env: { PATH: join(root, 'npm'), PNPM_HOME: '', LOCALAPPDATA: '', APPDATA: '' },
+      home: root,
+      execPath: join(root, 'node.exe'),
+    })).toEqual({ file: 'pnpm', prefix: [] })
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('lists Windows pnpm search dirs including PNPM_HOME', () => {
+    const local = 'C:/Users/x/AppData/Local'
+    const roaming = 'C:/Users/x/AppData/Roaming'
+    expect(toolSearchDirs('win32', {
+      PNPM_HOME: 'D:/pnpm',
+      LOCALAPPDATA: local,
+      APPDATA: roaming,
+    }, 'C:/Users/x', 'C:/nodejs')).toEqual([
+      'D:/pnpm',
+      join(local, 'pnpm'),
+      join(roaming, 'npm'),
+      'C:/nodejs',
+    ])
   })
 
   it('quotes spaces and embedded double quotes without changing plain tokens', () => {
@@ -46,6 +104,21 @@ describe('plugin command errors', () => {
   it('explains the platform command limit in the timeout error', () => {
     expect(commandError({ exitCode: null, timedOut: true, stdout: '', stderr: '' }))
       .toBe('插件命令执行超时，已停止；请复制日志查看失败步骤')
+  })
+
+  it('maps direct pnpm spawn ENOENT to actionable bilingual guidance', () => {
+    expect(commandError({
+      exitCode: null,
+      timedOut: false,
+      stdout: '',
+      stderr: 'spawn pnpm ENOENT',
+    })).toBe(PNPM_DIRECT_SPAWN_ENOENT_HINT)
+    expect(commandError({
+      exitCode: null,
+      timedOut: false,
+      stdout: '',
+      stderr: PNPM_DIRECT_SPAWN_ENOENT_HINT,
+    })).toBe(PNPM_DIRECT_SPAWN_ENOENT_HINT)
   })
 })
 

--- a/tests/lifecycle-install-safety.spec.ts
+++ b/tests/lifecycle-install-safety.spec.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { loadCatalog } from '../src/catalog.ts'
 import type { CommandOptions, CommandResult, PluginRunner } from '../src/commands.ts'
 import { SkinLifecycle } from '../src/lifecycle.ts'
-import { atomicWriteJson, atomicWriteText, ensurePatchedDependency, profilePatchFile, readDependencies } from '../src/profile.ts'
+import { atomicWriteJson, atomicWriteText, ensurePatchedDependency, profilePatchFile, readDependencies, readMarketState } from '../src/profile.ts'
 import * as profile from '../src/profile.ts'
 import type { Operation, SkinEntry } from '../src/types.ts'
 
@@ -283,6 +283,100 @@ describe('installation boundaries', () => {
     await vi.advanceTimersByTimeAsync(100)
     expect(operation.phase).toBe('failed')
     expect(installs).toBe(2)
+    expect(readFileSync(join(dir, 'package.json'), 'utf8')).toBe(before)
+  })
+
+  it('rejects a truncated &path: prefetch that materializes the wrong root package', async () => {
+    const { dir, skin } = fixture()
+    const commit = 'b'.repeat(40)
+    skin.package = '@dsh-external/dsh-client-ui-skin-maid-atelier'
+    skin.install = {
+      target: `github:example/dsh-deep-whale#${commit}&path:/maid-atelier`,
+      version: '1.0.0',
+      commit,
+    }
+    const before = readFileSync(join(dir, 'package.json'), 'utf8')
+    const runner: PluginRunner = async (_profile, args) => {
+      const targetDir = args.includes('--dir') ? args[args.indexOf('--dir') + 1]! : dir
+      // Simulate shell/cmd truncating left-of-&: pnpm exits 0 with the repo root.
+      const wrong = 'dsh-deep-whale'
+      mkdirSync(join(targetDir, 'node_modules', wrong), { recursive: true })
+      atomicWriteJson(join(targetDir, 'package.json'), { dependencies: { [wrong]: `github:example/dsh-deep-whale#${commit}` } })
+      atomicWriteJson(join(targetDir, 'node_modules', wrong, 'package.json'), {
+        name: wrong,
+        version: '0.0.1',
+        dsh: { client: { platform: 'web' } },
+      })
+      return ok()
+    }
+    const lifecycle = new SkinLifecycle({ loader: { entries: () => [] } }, { profile: 'test', profileDir: dir, runner }, [skin])
+    const operation = lifecycle.begin('install', skin.id)
+    await until(() => operation.phase === 'failed')
+    expect(operation.message).toContain('manifest missing')
+    expect(operation.message).toContain('&path:')
+    expect(operation.message).not.toContain('请用市场一键安装')
+    expect(readFileSync(join(dir, 'package.json'), 'utf8')).toBe(before)
+    expect(existsSync(join(dir, 'node_modules', skin.package))).toBe(false)
+  })
+
+  it('rejects a truncated companion &path: add before claiming market ownership', async () => {
+    const { dir, skin } = fixture()
+    const commit = 'c'.repeat(40)
+    const companion = {
+      package: '@dsh-external/dsh-client-ui-skin-deep-whale-manager',
+      target: `github:example/dsh-deep-whale#${commit}&path:/skin-manager`,
+      version: '0.1.0',
+      commit,
+      rowId: 'ui-skin-deep-whale-manager',
+    }
+    skin.package = '@dsh-external/dsh-client-ui-skin-maid-atelier'
+    skin.rowId = 'ui-skin-maid-atelier'
+    skin.install = {
+      target: `github:example/dsh-deep-whale#${commit}&path:/maid-atelier`,
+      version: '1.0.0',
+      commit,
+      companions: [companion],
+    }
+    const before = readFileSync(join(dir, 'package.json'), 'utf8')
+    const runner: PluginRunner = async (_profile, args) => {
+      const targetDir = args.includes('--dir') ? args[args.indexOf('--dir') + 1]! : dir
+      const spec = args[1]!
+      if (args.includes('--dir')) {
+        // Prefetch of the main skin succeeds with the expected package.
+        const pkgDir = join(targetDir, 'node_modules', ...skin.package.split('/'))
+        mkdirSync(pkgDir, { recursive: true })
+        atomicWriteJson(join(targetDir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
+        atomicWriteJson(join(pkgDir, 'package.json'), {
+          name: skin.package,
+          version: skin.install.version,
+          dsh: { client: { platform: 'web' } },
+        })
+        return ok()
+      }
+      if (spec === companion.target) {
+        // Live companion add truncated: wrong root, missing companion package.
+        const wrong = 'dsh-deep-whale'
+        mkdirSync(join(dir, 'node_modules', wrong), { recursive: true })
+        atomicWriteJson(join(dir, 'package.json'), { dependencies: { [wrong]: `github:example/dsh-deep-whale#${commit}` } })
+        atomicWriteJson(join(dir, 'node_modules', wrong, 'package.json'), {
+          name: wrong,
+          version: '0.0.1',
+          dsh: { client: { platform: 'web' } },
+        })
+        return ok()
+      }
+      // Should not reach main live add if companion validation fails.
+      return { ...ok(), exitCode: 1, stderr: `unexpected live add ${spec}` }
+    }
+    const lifecycle = new SkinLifecycle({ loader: { entries: () => [] } }, { profile: 'test', profileDir: dir, runner }, [skin])
+    const operation = lifecycle.begin('install', skin.id)
+    await until(() => operation.phase === 'failed')
+    expect(operation.message).toContain(companion.package)
+    expect(operation.message).toMatch(/manifest missing|name mismatch/)
+    expect(operation.message).toContain('&path:')
+    expect(readMarketState(dir).managedCompanions).toBeUndefined()
+    expect(existsSync(join(dir, 'node_modules', ...companion.package.split('/')))).toBe(false)
+    // Recovery restores the pre-install package.json snapshot.
     expect(readFileSync(join(dir, 'package.json'), 'utf8')).toBe(before)
   })
 })

--- a/tests/lifecycle.spec.ts
+++ b/tests/lifecycle.spec.ts
@@ -53,6 +53,21 @@ function writeBundleRows(dir: string, skin: { package: string; install: { versio
   atomicWriteText(join(packageDir, 'cordis.patch.yml'), `- insert:\n${rows.map(row => `    - id: ${row.id}\n      name: ${JSON.stringify(row.name)}`).join('\n')}\n`)
 }
 
+
+function materializeReviewedSkin(targetDir: string, skin: { package: string; rowId: string; install: { version: string; target: string } }, bundle = true): void {
+  const manifestPath = join(targetDir, 'package.json')
+  const existing = existsSync(manifestPath)
+    ? JSON.parse(readFileSync(manifestPath, 'utf8')) as { dependencies?: Record<string, string> }
+    : {}
+  atomicWriteJson(manifestPath, { ...existing, dependencies: { ...existing.dependencies, [skin.package]: skin.install.target } })
+  if (bundle) writeBundlePackage(targetDir, skin)
+  else {
+    const packageDir = join(targetDir, 'node_modules', ...skin.package.split('/'))
+    mkdirSync(packageDir, { recursive: true })
+    atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
+  }
+}
+
 function syncPatchLockfile(dir: string): void {
   const workspace = parse(readFileSync(pnpmWorkspaceFile(dir), 'utf8')) as { patchedDependencies?: Record<string, unknown> }
   const patchedDependencies = Object.fromEntries(Object.entries(workspace.patchedDependencies ?? {}).flatMap(([key, value]) => {
@@ -400,13 +415,11 @@ describe('skin lifecycle', () => {
       attempts.push(args)
       if (args.includes('--dir')) {
         if (!args.includes('--config.minimumReleaseAge=0')) return { ...success(), exitCode: 1, stderr: 'published within the minimumReleaseAge cutoff' }
+        materializeReviewedSkin(args[args.indexOf('--dir') + 1]!, base, false)
         return success()
       }
       if (args[0] === 'add') {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { [base.package]: base.install.target } })
-        const packageDir = join(dir, 'node_modules', ...base.package.split('/'))
-        mkdirSync(packageDir, { recursive: true })
-        atomicWriteJson(join(packageDir, 'package.json'), { name: base.package, version: base.install.version, dsh: { client: { platform: 'web' } } })
+        materializeReviewedSkin(dir, base, false)
       }
       return success()
     }
@@ -440,12 +453,10 @@ describe('skin lifecycle', () => {
       if (args.includes('--dir')) {
         const temporary = args[args.indexOf('--dir') + 1]!
         expect(readFileSync(join(temporary, 'pnpm-workspace.yaml'), 'utf8')).toContain(`${allowBuild}#path:/packages/dsh-web-ui-all`)
+        materializeReviewedSkin(temporary, skin, false)
       }
       if (args[0] === 'add' && !args.includes('--dir')) {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
-        const packageDir = join(dir, 'node_modules', ...skin.package.split('/'))
-        mkdirSync(packageDir, { recursive: true })
-        atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
+        materializeReviewedSkin(dir, skin, false)
       }
       return success()
     }
@@ -476,7 +487,10 @@ describe('skin lifecycle', () => {
     let compatibilityInstallCalls = 0
     let compatibilityInstallArgs: readonly string[] = []
     const runner: PluginRunner = async (_profile, args) => {
-      if (args.includes('--dir')) return success()
+      if (args.includes('--dir')) {
+        materializeReviewedSkin(args[args.indexOf('--dir') + 1]!, skin, false)
+        return success()
+      }
       if (args[0] === 'add') {
         atomicWriteJson(join(dir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
         const packageDir = join(dir, 'node_modules', ...skin.package.split('/'))
@@ -580,6 +594,10 @@ describe('skin lifecycle', () => {
     const runner: PluginRunner = async (_profile, args) => {
       installArgs.push(args)
       if (args[0] === 'install') syncPatchLockfile(dir)
+      if (args.includes('--dir')) {
+        materializeReviewedSkin(args[args.indexOf('--dir') + 1]!, { ...skin, install: { ...skin.install, target: skin.install.target } }, false)
+        return success()
+      }
       if (args[0] === 'add' && !args.includes('--dir')) {
         atomicWriteJson(join(dir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
         atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
@@ -651,6 +669,7 @@ describe('skin lifecycle', () => {
           return { ...success(), exitCode: 1, stderr: `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED\n${buildKey} needs to execute build scripts but is not in allowBuilds` }
         }
         prefetchApprovals.push(readFileSync(workspaceFile, 'utf8'))
+        materializeReviewedSkin(temporary, skin, false)
         return success()
       }
       if (args[0] === 'add' && !rejected) {
@@ -658,10 +677,7 @@ describe('skin lifecycle', () => {
         return { ...success(), exitCode: 1, stderr: `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED\n${buildKey} needs to execute build scripts but is not in allowBuilds` }
       }
       if (args[0] === 'add') {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
-        const packageDir = join(dir, 'node_modules', ...skin.package.split('/'))
-        mkdirSync(packageDir, { recursive: true })
-        atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
+        materializeReviewedSkin(dir, skin, false)
       }
       return success()
     }
@@ -700,13 +716,11 @@ describe('skin lifecycle', () => {
       if (args.includes('--dir')) {
         const temporary = args[args.indexOf('--dir') + 1]!
         expect(readFileSync(join(temporary, 'pnpm-workspace.yaml'), 'utf8')).toContain(buildKey)
+        materializeReviewedSkin(temporary, skin, false)
         return success()
       }
       if (args[0] === 'add') {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
-        const packageDir = join(dir, 'node_modules', ...skin.package.split('/'))
-        mkdirSync(packageDir, { recursive: true })
-        atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
+        materializeReviewedSkin(dir, skin, false)
       }
       return success()
     }
@@ -725,16 +739,16 @@ describe('skin lifecycle', () => {
     const skin = { ...base, id: 'ignored-build.skin', install: { ...base.install, allowBuild: undefined } }
     let rejected = false
     const runner: PluginRunner = async (_profile, args) => {
-      if (args.includes('--dir')) return success()
+      if (args.includes('--dir')) {
+        materializeReviewedSkin(args[args.indexOf('--dir') + 1]!, skin, false)
+        return success()
+      }
       if (args[0] === 'add' && !rejected) {
         rejected = true
         return { ...success(), exitCode: 1, stderr: 'ERR_PNPM_IGNORED_BUILDS\nIgnored build scripts: node-pty@1.1.0' }
       }
       if (args[0] === 'add') {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { [skin.package]: skin.install.target } })
-        const packageDir = join(dir, 'node_modules', ...skin.package.split('/'))
-        mkdirSync(packageDir, { recursive: true })
-        atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
+        materializeReviewedSkin(dir, skin, false)
       }
       return success()
     }
@@ -803,9 +817,11 @@ describe('skin lifecycle', () => {
     const runner: PluginRunner = async (_profile, args) => {
       const skin = lifecycle.catalog.find(item => args.includes(item.install.target) || args.includes(item.package))
       if (args[0] === 'add' && skin !== undefined) {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { ...readDependencies(dir), [skin.package]: skin.install.target } })
-        writeBundlePackage(dir, skin)
-        entries.set(skin.rowId, { options: { id: skin.rowId, name: skin.rowId, disabled: true }, update: async function (value) { updates.push(`${skin.rowId}:${String(value.disabled)}`); this.options.disabled = value.disabled; this.fiber = value.disabled ? undefined : {} } })
+        const targetDir = args.includes('--dir') ? args[args.indexOf('--dir') + 1]! : dir
+        materializeReviewedSkin(targetDir, skin)
+        if (!args.includes('--dir')) {
+          entries.set(skin.rowId, { options: { id: skin.rowId, name: skin.rowId, disabled: true }, update: async function (value) { updates.push(`${skin.rowId}:${String(value.disabled)}`); this.options.disabled = value.disabled; this.fiber = value.disabled ? undefined : {} } })
+        }
       }
       if (args[0] === 'remove' && skin !== undefined) {
         const next = { ...readDependencies(dir) }
@@ -854,16 +870,18 @@ describe('skin lifecycle', () => {
     const runner: PluginRunner = async (_profile, args) => {
       const skin = lifecycle.catalog.find(item => args.includes(item.install.target) || args.includes(item.package))
       if (args[0] === 'add' && skin !== undefined) {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { ...readDependencies(dir), [skin.package]: skin.install.target } })
-        writeBundlePackage(dir, skin)
-        entries.set(skin.rowId, {
-          options: { id: skin.rowId, name: skin.rowId, disabled: true },
-          update: async function (value) {
-            updates.push(`${skin.rowId}:${String(value.disabled)}`)
-            this.options.disabled = value.disabled
-            this.fiber = value.disabled ? undefined : {}
-          },
-        })
+        const targetDir = args.includes('--dir') ? args[args.indexOf('--dir') + 1]! : dir
+        materializeReviewedSkin(targetDir, skin)
+        if (!args.includes('--dir')) {
+          entries.set(skin.rowId, {
+            options: { id: skin.rowId, name: skin.rowId, disabled: true },
+            update: async function (value) {
+              updates.push(`${skin.rowId}:${String(value.disabled)}`)
+              this.options.disabled = value.disabled
+              this.fiber = value.disabled ? undefined : {}
+            },
+          })
+        }
       }
       return success()
     }
@@ -988,10 +1006,8 @@ describe('skin lifecycle', () => {
       const skin = lifecycle.catalog.find(item => args.includes(item.install.target) || args.includes(item.package))
       if (skin === undefined) return success()
       if (args[0] === 'add') {
-        atomicWriteJson(join(dir, 'package.json'), { dependencies: { ...readDependencies(dir), [skin.package]: skin.install.target } })
-        const packageDir = join(dir, 'node_modules', ...skin.package.split('/'))
-        mkdirSync(packageDir, { recursive: true })
-        atomicWriteJson(join(packageDir, 'package.json'), { name: skin.package, version: skin.install.version, dsh: { client: { platform: 'web' } } })
+        const targetDir = args.includes('--dir') ? args[args.indexOf('--dir') + 1]! : dir
+        materializeReviewedSkin(targetDir, skin, false)
       }
       if (args[0] === 'remove') {
         const next = { ...readDependencies(dir) }
@@ -1035,7 +1051,11 @@ describe('skin lifecycle', () => {
     atomicWriteText(profilePatchFile(dir), `- insert:\n    - id: ${skin.rowId}\n      name: another-plugin\n`)
     let liveAdd = 0
     const runner: PluginRunner = async (_profile, args) => {
-      if (args[0] === 'add' && !args.includes('--dir')) liveAdd += 1
+      if (args.includes('--dir')) {
+        materializeReviewedSkin(args[args.indexOf('--dir') + 1]!, skin)
+        return success()
+      }
+      if (args[0] === 'add') liveAdd += 1
       return success()
     }
     const lifecycle = new SkinLifecycle({ loader: { entries: () => [] } }, { profile: 'test', profileDir: dir, runner }, [skin])
@@ -1172,7 +1192,13 @@ describe('skin lifecycle', () => {
       install: { ...one.install, target: `github:example/repo#${commit}&path:/two` },
     }
     const runner: PluginRunner = async (_profile, args) => {
-      if (args[0] === 'add' && args.includes('--dir')) return success()
+      if (args[0] === 'add' && args.includes('--dir')) {
+        const temporary = args[args.indexOf('--dir') + 1]!
+        const spec = args[1]!
+        const added = spec === one.install.target ? one : spec === two.install.target ? two : null
+        if (added !== null) materializeReviewedSkin(temporary, { package: added.package, rowId: added.rowId, install: { version: added.install.version, target: added.install.target } })
+        return success()
+      }
       if (args[0] === 'add') {
         const spec = args[1]!
         const dependencies = { ...readDependencies(dir) }
@@ -1278,7 +1304,10 @@ describe('skin lifecycle', () => {
     const calls: string[][] = []
     const runner: PluginRunner = async (_profile, args) => {
       calls.push([...args])
-      if (args[0] === 'add' && args.includes('--dir')) return success()
+      if (args[0] === 'add' && args.includes('--dir')) {
+        materializeReviewedSkin(args[args.indexOf('--dir') + 1]!, skin)
+        return success()
+      }
       if (args[0] === 'add' && args[1] === skin.install.target) {
         atomicWriteJson(join(dir, 'package.json'), {
           dependencies: { ...readDependencies(dir), [skin.package]: skin.install.target },
@@ -1415,7 +1444,13 @@ describe('skin lifecycle', () => {
       install: { target: `github:example/repo#${commit}&path:/two`, version: '1.0.0', commit },
     }
     const runner: PluginRunner = async (_profile, args) => {
-      if (args[0] === 'add' && args.includes('--dir')) return success()
+      if (args[0] === 'add' && args.includes('--dir')) {
+        const temporary = args[args.indexOf('--dir') + 1]!
+        const spec = args[1]!
+        const added = spec === owner.install.target ? owner : spec === other.install.target ? other : null
+        if (added !== null) materializeReviewedSkin(temporary, { package: added.package, rowId: added.rowId, install: { version: added.install.version, target: added.install.target } })
+        return success()
+      }
       if (args[0] === 'add') {
         const spec = args[1]!
         const added = spec === companion.target

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -373,6 +373,30 @@ describe('profile state', () => {
     })
   })
 
+  it('explains &path: truncation when the reviewed subdirectory package is missing', () => {
+    const dir = fixture()
+    const commit = 'c'.repeat(40)
+    const skin = {
+      ...loadCatalog().skins[0],
+      package: '@scope/subdir-skin',
+      install: {
+        target: `github:example/monorepo#${commit}&path:/packages/skin`,
+        version: '1.0.0',
+        commit,
+      },
+    }
+    const wrongDir = join(dir, 'node_modules', 'monorepo-root')
+    mkdirSync(wrongDir, { recursive: true })
+    atomicWriteJson(join(wrongDir, 'package.json'), { name: 'monorepo-root', version: '9.9.9', dsh: { client: { platform: 'web' } } })
+
+    const result = validateInstalledSkin(dir, skin)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('manifest missing')
+    expect(result.reason).toContain('&path:')
+    expect(result.reason).toContain('截断')
+    expect(result.reason).not.toContain('请用市场一键安装')
+  })
+
   it('reports a broken bundle patch before registration mutates the profile', () => {
     const dir = fixture()
     const skin = loadCatalog().skins[0]


### PR DESCRIPTION
## Summary
- **Root cause:** On Windows, `dsh plugin add` / cmd.exe can truncate GitHub subdirectory specs at `&` in `github:…#commit&path:/subdir`, so pnpm installs the **repo root** package instead of the skin. That can look like a successful install while the wrong package lands in the profile.
- **Changes:** Keep subdirectory GitHub specs as a single argv element for direct `pnpm` spawn (`viaShell: false`); resolve a real pnpm binary via `resolvePnpmForDirectSpawn`; after install, validate main + companion package identity in `node_modules` so a truncated `&path:` cannot false-succeed as the repo root (bilingual truncation hint).
- Files: `src/commands.ts`, `src/lifecycle.ts`, `src/profile.ts` (+ rebuilt `lib/`), README note, focused tests.

## Test plan
- [x] Focused vitest (127 tests): `commands`, `commands-process`, `install-resolution`, `lifecycle-install-safety`, `profile`, `lifecycle`
- [x] Local Linux DSH web-profile verification (see box `/workspace/dsh-skin-path-repro/LOCAL-INSTALL-TEST.md`):
  - maid-atelier `&path:` via market `pluginProcess` — PASS
  - companion skin-manager `&path:` — PASS
  - truncation false-success guard (`validateInstalledSkin`) — PASS
  - `resolvePnpmForDirectSpawn` / argv shape — PASS
- [ ] Real Windows `pnpm.exe` / Corepack path still needs a production smoke after release (unit tests cover win32 fakes)

## Release / publish
**Do not npm publish from this PR alone.** After merge to `main`, publish needs npm auth (currently `npm whoami` → 401 on this Mac) then:

```bash
npm run release -- 0.1.50
```