### PR TITLE
feat(registry): add dsh-skin-Yumemizuki

### DIFF
--- a/registry/skins/a39485972-sudo__dsh-skin-Yumemizuki.yml
+++ b/registry/skins/a39485972-sudo__dsh-skin-Yumemizuki.yml
@@ -1,0 +1,1 @@
+url: https://github.com/a39485972-sudo/dsh-skin-Yumemizuki


### PR DESCRIPTION
新增收录：https://github.com/a39485972-sudo/dsh-skin-Yumemizuki （tag `0.9`）
条目：`registry/skins/a39485972-sudo__dsh-skin-Yumemizuki.yml`（薄条目，仅 `url:`）
本地校验：`npm run registry:check` → `validated 301 skins`；仅新增该 1 个文件，未改 `data/catalog.json`。
收录不等于安全认证，不代表官方或市场背书。